### PR TITLE
release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### ~
 
+### v0.3.0
+* adds "moon" calendar (moonrise, moonset) (#9).
+* adds "astronomical twilight", "nautical twilight", and "civil twilight" calendars (sunrise, sunset) (#9).
+* enhances the progress UI; improved dialog and notifications.
+* now requires Suntimes v0.10.3+ (previously v0.10.0).
+
 ### v0.2.0 (2019-01-02)
 * adds individual "enabled" prefs for each calendar (Solstices/Equinoxes, Moon Phases) (#3).
 * fixes bug "missing calendars/events when closing app while task is still running" (#4); moves calendar notifications into a foreground service. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### ~
 
-### v0.3.0
+### v0.3.0 (2019-03-25)
 * adds "moon" calendar (moonrise, moonset) (#9).
 * adds "astronomical twilight", "nautical twilight", and "civil twilight" calendars (sunrise, sunset) (#9).
 * enhances the progress UI; improved dialog and notifications.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "com.forrestguice.suntimescalendars"
         minSdkVersion 11
         targetSdkVersion 25
-        versionCode 3
-        versionName "0.2.0"
+        versionCode 4
+        versionName "0.3.0"
 
         buildConfigField "java.util.Date", "BUILD_TIME", "new java.util.Date(" + getDateAsMillis() + "L)"
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""


### PR DESCRIPTION
* adds "moon" calendar (moonrise, moonset) (#9).
* adds "astronomical twilight", "nautical twilight", and "civil twilight" calendars (sunrise, sunset) (#9).
* enhances the progress UI; improved dialog and notifications.
* updates translations to Polish (pl) and Esperanto (eo) (#12 by Verdulo).
* now requires Suntimes v0.10.3+ (previously v0.10.0).