### PR TITLE
shortened names in metdata, becouse it is limited to 30 characters

### DIFF
--- a/fastlane/metadata/android/eo/name.txt
+++ b/fastlane/metadata/android/eo/name.txt
@@ -1,1 +1,1 @@
-Suntempoj: kalendaro | Suntimes Calendars
+Suntempoj: kalendaro

--- a/fastlane/metadata/android/pl/name.txt
+++ b/fastlane/metadata/android/pl/name.txt
@@ -1,1 +1,1 @@
-Czasy Słońca: kalendarz | Suntimes Calendars
+Czasy Słońca: kalendarz


### PR DESCRIPTION
mallongigis nomojn en metadatumoj, ĉar ili estas limigitaj al 30 signoj