### PR TITLE
release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 ### ~
 
-### v0.5.0 (2020-11-09)
-* adds support for add-on calendars; add-on apps may now declare their own calendars. These calendars will show up in the list automatically when available.
-* refactors CalendarTask and supporting classes (rewrite); default calendars are now defined as part of the manifest.
+### v0.5.0 (2020-11-20)
+* adds support for add-on calendars; add-on apps may now declare their own calendars (e.g. https://github.com/forrestguice/SolunarPeriods). These calendars will show up in the list automatically when available.
 * misc UI changes; enhances "Calendar Window" preference, adds ActionBar, adds "Open Calendar" menu item, moves "About" to overflow menu.
+* refactors CalendarTask and supporting classes (rewrite).
 
 ### v0.4.2 (2020-09-24)
 * enhances color selection; use external color picker if available (#25) (requires Suntimes v0.13.0+).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ### ~
 
+### v0.5.0 (2020-11-09)
+* adds support for add-on calendars; add-on apps may now declare their own calendars. These calendars will show up in the list automatically when available.
+* refactors CalendarTask and supporting classes (rewrite); default calendars are now defined as part of the manifest.
+* misc UI changes; enhances "Calendar Window" preference, adds ActionBar, adds "Open Calendar" menu item, moves "About" to overflow menu.
+
 ### v0.4.2 (2020-09-24)
 * enhances color selection; use external color picker if available (#25) (requires Suntimes v0.13.0+).
 * fixes bug that prevents adding Moon Apsis calendar. 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An add-on for [Suntimes](https://github.com/forrestguice/SuntimesWidget) that su
 
 [![F-Droid](https://img.shields.io/f-droid/v/com.forrestguice.suntimescalendars.svg)](https://f-droid.org/en/packages/com.forrestguice.suntimescalendars/)
 [![GitHub release](https://img.shields.io/github/release/forrestguice/SuntimesCalendars.svg)](https://github.com/forrestguice/SuntimesCalendars/releases)
-[![Build Status](https://travis-ci.org/forrestguice/SuntimesCalendars.svg?branch=master)](https://travis-ci.org/forrestguice/SuntimesCalendars)
+[![Android CI](https://github.com/forrestguice/SuntimesWidget/workflows/Android%20CI/badge.svg?branch=master)](https://github.com/forrestguice/SuntimesCalendars/actions?query=branch%3Amaster)
 
 * [Privacy and Permissions](#privacy-and-permissions)
 * [Donations](#donations)
@@ -34,7 +34,7 @@ The app requires the following permissions...
 
 ## Donations ##
 
-Do you find value in this software? Please pay as you feel. Putting a price on the binary is a great way to show support for software you care about. 
+Do you find value in this software? Please pay as you feel. 
 
 [![paypal](https://www.paypalobjects.com/webstatic/en_US/i/btn/png/silver-rect-paypal-26px.png)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=NZJ5FJBCKY6K2)
 

--- a/README.md
+++ b/README.md
@@ -62,4 +62,4 @@ Basque translation by <u>beriain</u>.<br/>
 Norwegian translation by <u>FTno</u>.<br/>
 Italian translation by <u>Matteo Caoduro</u>.<br/>
 Traditional Chinese translation by <u><a href=https://github.com/pggdt>ft42</a></u>.<br />
-Brazilian Portuguese translation by <u><a href=https://github.com/netosilva15>NetoSilva</a></u>.<br />
+Brazilian Portuguese translation by <u><a href=https://github.com/netosilva15>NetoSilva</a></u>, <u><a href=https://github.com/naoliv>Nelson&#160;A.&#160;de&#160;Oliveira</a></u>, and <u><a href=https://github.com/efraletti>Enrico S. B. Fraletti</a></u>.<br />

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ Do you find value in this software? Please pay as you feel. Putting a price on t
 
 ## Bug Reports ##
 
-You can report bugs using the issue tracker. 
+Use the issue tracker to submit a bug report or a feature request.
 
-When submitting a bug please be detailed and specific. What did you expect the app to do, what did you actually observe? Bugs that can't be reproduced won't get fixed. Useful information includes Android OS version and your specific device model.
+When reporting a bug **please be detailed as possible**. What did you expect the app to do, what did you actually observe? Include the app version number in your report. Other useful information includes the Android OS version (and sometimes your specific device model).
 
 ## Legal Stuff
 Copyright © 2018-2020 Forrest Guice <br />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         minSdkVersion 11
         //noinspection ExpiredTargetSdkVersion
         targetSdkVersion 25
-        versionCode 9
-        versionName "0.4.2"
+        versionCode 10
+        versionName "0.5.0"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,37 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+-dontobfuscate
+
+-keepclassmembers class * implements com.forrestguice.suntimeswidget.calendar.task.SuntimesCalendar {
+   public <init>();
+}
+-keep public class * extends com.forrestguice.suntimeswidget.calendar.task.calendars.SuntimesCalendarBase
+
+-keep public class * extends android.view.View {
+     public <init>(android.content.Context);
+     public <init>(android.content.Context, android.util.AttributeSet);
+     public <init>(android.content.Context, android.util.AttributeSet, int);
+     void set*(***);
+     *** get*();
+}
+-keep public class * extends android.preference.Preference {
+     public <init>(android.content.Context);
+     public <init>(android.content.Context, android.util.AttributeSet);
+     public <init>(android.content.Context, android.util.AttributeSet, int);
+     public <init>(android.content.Context, android.util.AttributeSet, int, int);
+     void set*(***);
+}
+-keepclassmembers enum * {
+    public static **[] values();
+    public static ** valueOf(java.lang.String);
+}
+-keepclassmembers class * implements android.os.Parcelable {
+    public static final ** CREATOR;
+}
+
+# keep MenuBuilder .. reflection used by `forceActionBarIcons`
+-keepclassmembers class **.MenuBuilder {
+    void setOptionalIconsVisible(boolean);
+}

--- a/fastlane/metadata/android/en-US/changelogs/10.txt
+++ b/fastlane/metadata/android/en-US/changelogs/10.txt
@@ -1,0 +1,2 @@
+- adds support for "add-on calendars".
+- miscellaneous UI changes.

--- a/fastlane/metadata/android/en-US/changelogs/10.txt
+++ b/fastlane/metadata/android/en-US/changelogs/10.txt
@@ -1,2 +1,2 @@
-- adds support for "add-on calendars".
+- support for add-on calendars.
 - miscellaneous UI changes.


### PR DESCRIPTION
* adds support for add-on calendars; add-on apps may now declare their own calendars. These calendars will show up in the list automatically when available.
* refactors CalendarTask and supporting classes (rewrite); default calendars are now defined as part of the manifest.
* misc UI changes; enhances "Calendar Window" preference, adds ActionBar, adds "Open Calendar" menu item, moves "About" to overflow menu.