### PR TITLE
release 0.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### ~
 
+### v0.5.5 (2021-11-15)
+* updates translations to Polish (pl) and Esperanto (eo) (#44 by Verdulo).
+* fixes "app crash when clicking the `Open Calendar` button" (#43).
+
 ### v0.5.4 (2021-06-16)
 * updates translation to German (de) (#41 by wolkenschieber).
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         minSdkVersion 11
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 25
-        versionCode 14
-        versionName "0.5.4"
+        versionCode 15
+        versionName "0.5.5"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/15.txt
+++ b/fastlane/metadata/android/en-US/changelogs/15.txt
@@ -1,0 +1,1 @@
+- updates translations to Polish and Esperanto.


### PR DESCRIPTION
* updates translations to Polish (pl) and Esperanto (eo) (#44 by Verdulo).
* fixes "app crash when clicking the `Open Calendar` button" (closes #43).