### PR TITLE
release 0.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ### ~
 
+### v0.5.6 (2022-12-05)
+* updates translation to Norwegian (nb) (#49 by FTno).
+
 ### v0.5.5 (2021-11-15)
 * updates translations to Polish (pl) and Esperanto (eo) (#44 by Verdulo).
 * fixes "app crash when clicking the `Open Calendar` button" (#43).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ### ~
 
 ### v0.5.6 (2022-12-05)
+* adds support for system dark mode (night mode).
+* fixes bug where Toasts are unreadable (white-on-white); Android 13 (api33+).
+* updates build; gradle wrapper to `gradle-5.0`.
 * updates translation to Norwegian (nb) (#49 by FTno).
 
 ### v0.5.5 (2021-11-15)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         minSdkVersion 11
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 25
-        versionCode 15
-        versionName "0.5.5"
+        versionCode 16
+        versionName "0.5.6"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/16.txt
+++ b/fastlane/metadata/android/en-US/changelogs/16.txt
@@ -1,0 +1,1 @@
+- updates translation to Norwegian.


### PR DESCRIPTION
* adds support for system dark mode (night mode).
* fixes bug where Toasts are unreadable (white-on-white); Android 13 (api33+).
* updates build; gradle wrapper to `gradle-5.0`.
* updates translation to Norwegian (nb) (#49 by FTno).