### PR TITLE
release 0.5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ### ~
 
+### v0.5.7 (2023-02-10)
+* adds support for high contrast themes and text size (Suntimes v0.15.0+).
+* updates Suntimes CalculatorProviderContract; from v2 to v5.
+* updates translation to Norwegian (nb) (#52 by FTno).
+
 ### v0.5.6 (2022-12-05)
 * adds support for system dark mode (night mode).
 * fixes bug where Toasts are unreadable (white-on-white); Android 13 (api33+).

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
         minSdkVersion 11
         //noinspection ExpiredTargetSdkVersion,OldTargetApi
         targetSdkVersion 25
-        versionCode 16
-        versionName "0.5.6"
+        versionCode 17
+        versionName "0.5.7"
 
         buildConfigField "String", "GIT_HASH", "\"${getGitHash()}\""
 

--- a/fastlane/metadata/android/en-US/changelogs/17.txt
+++ b/fastlane/metadata/android/en-US/changelogs/17.txt
@@ -1,0 +1,1 @@
+- updates translation to Norwegian.


### PR DESCRIPTION
* adds support for high contrast themes and text size (Suntimes v0.15.0+).
* updates Suntimes CalculatorProviderContract; from v2 to v5.
* updates translation to Norwegian (nb) (#52 by FTno).