### PR TITLE
patterns

### DIFF
--- a/app/src/main/java/com/forrestguice/suntimeswidget/calculator/core/CalculatorProviderContract.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calculator/core/CalculatorProviderContract.java
@@ -20,7 +20,7 @@ package com.forrestguice.suntimeswidget.calculator.core;
 
 /**
  * CalculatorProviderContract
- * @version 5 (0.5.0)
+ * @version 7 (0.6.0)
  *
  * Supported URIs have the form: "content://AUTHORITY/query"
  * ..where [AUTHORITY] is "suntimeswidget.calculator.provider"
@@ -198,7 +198,7 @@ package com.forrestguice.suntimeswidget.calculator.core;
  *   The permission is granted by the user when an app is installed (and revoked if the provider is
  *   uninstalled/reinstalled).
  *
- *       <uses-permission android:name="suntimeswidget.calculator.permission.READ_PROVIDER" />
+ *       <uses-permission android:name="suntimeswidget.calculator.permission.READ_CALCULATOR" />
  *
  *   Note that calling query without the necessary permission will result in a SecurityException.
  *       try {
@@ -227,13 +227,16 @@ package com.forrestguice.suntimeswidget.calculator.core;
  *     deprecates COLUMN_SEASON_VERNAL and replaces it with COLUMN_SEASON_SPRING
  *     adds COLUMN_CONFIG_APP_TEXT_SIZE
  *     adds COLUMN_SUNPOS_EOT, COLUMN_CONFIG_TIMEZONEMODE, COLUMN_CONFIG_SOLARTIMEMODE
+ *   6 fixes ambiguity of COLUMN_SEASON_CROSS_* columns; e.g. CROSS_SUMMER is the midpoint between summer solstice and autumn equinox.
+ *   7 adds COLUMN_MOON_SET_ILLUM, COLUMN_MOON_SET_DISTANCE, COLUMN_MOON_SET_ILLUM, COLUMN_MOON_SET_DISTANCE.
+ *     adds _POSITION_KEYS; may be combined with COLUMN_MOON and COLUMN_SUN keys to specify position at time of event.
  */
 public interface CalculatorProviderContract
 {
     String AUTHORITY = "suntimeswidget.calculator.provider";
     String READ_PERMISSION = "suntimes.permission.READ_CALCULATOR";
-    String VERSION_NAME = "v0.5.0";
-    int VERSION_CODE = 5;
+    String VERSION_NAME = "v0.6.0";
+    int VERSION_CODE = 7;
 
     /**
      * CONFIG
@@ -285,6 +288,16 @@ public interface CalculatorProviderContract
     };
 
     /**
+     * POSITION
+     * Position keys that must be appended to other keys to form a valid combination;
+     * e.g. COLUMN_MOON_RISE + _POSITION_AZ is moon azimuth at time of rising
+     */
+    String _POSITION_AZ = "_azimuth";      // double
+    String _POSITION_ALT = "_altitude";    // double
+    String _POSITION_RA = "_ra";           // double
+    String _POSITION_DEC = "_dec";         // double
+
+    /**
      * SUN
      */
     String COLUMN_SUN_NOON = "solarnoon";                   // long (timestamp); (broken <= v0.10.2 [returns Calendar])
@@ -305,6 +318,9 @@ public interface CalculatorProviderContract
     String COLUMN_SUN_BLUE4_RISE = "blue4rise";             // long (timestamp); (broken <= v0.10.2 [returns Calendar])
     String COLUMN_SUN_BLUE8_SET = "blue8set";               // long (timestamp); (broken <= v0.10.2 [returns Calendar])
     String COLUMN_SUN_BLUE4_SET = "blue4set";               // long (timestamp); (broken <= v0.10.2 [returns Calendar])
+
+    // These columns may be combined with _POSITION keys: COLUMN_SUN_ACTUAL, COLUMN_SUN_CIVIL, COLUMN_SUN_NAUTICAL, COLUMN_SUN_ASTRO
+    // e.g. COLUMN_SUN_CIVIL_RISE + _POSITION_AZ = "sunrise_azimuth";         // double
 
     String QUERY_SUN = "sun";
     String[] QUERY_SUN_PROJECTION = new String[] {
@@ -342,8 +358,19 @@ public interface CalculatorProviderContract
     String COLUMN_MOON_RISE = "moonrise";                  // long (timestamp); (broken <= v0.10.2 [returns Calendar])
     String COLUMN_MOON_SET = "moonset";                    // long (timestamp); (broken <= v0.10.2 [returns Calendar])
 
+    String COLUMN_MOON_RISE_ILLUM = "moonrise_illum";        // double [0,1]
+    String COLUMN_MOON_RISE_DISTANCE = "moonrise_distance";  // double (kilometers)
+
+    String COLUMN_MOON_SET_ILLUM = "moonset_illum";        // double [0,1]
+    String COLUMN_MOON_SET_DISTANCE = "moonset_distance";  // double (kilometers)
+
+    // These columns may be combined with position keys: COLUMN_MOON_RISE, COLUMN_MOON_SET
+    // e.g. COLUMN_MOON_RISE + _POSITION_AZ = "moonrise_azimuth";       // double
+
     String QUERY_MOON = "moon";
-    String[] QUERY_MOON_PROJECTION = new String[] { COLUMN_MOON_RISE, COLUMN_MOON_SET };
+    String[] QUERY_MOON_PROJECTION = new String[] {
+            COLUMN_MOON_RISE,                 COLUMN_MOON_SET,
+    };
 
     /**
      * MOONPOS

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calendar/CalendarEventTemplate.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calendar/CalendarEventTemplate.java
@@ -98,4 +98,21 @@ public class CalendarEventTemplate implements Parcelable
         return TemplatePatterns.replaceSubstitutions(location, data);
     }
 
+    public boolean containsPattern(TemplatePatterns... patterns)
+    {
+        boolean retValue = false;
+        for (TemplatePatterns pattern : patterns) {
+            retValue = (retValue || containsPattern(pattern));
+            if (retValue) {
+                break;
+            }
+        }
+        return retValue;
+    }
+    public boolean containsPattern(TemplatePatterns p)
+    {
+        String pattern = p.getPattern();
+        return (title.contains(pattern) || desc.contains(pattern) || location.contains(pattern));
+    }
+
 }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calendar/SuntimesCalendarActivity.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calendar/SuntimesCalendarActivity.java
@@ -1046,6 +1046,7 @@ public class SuntimesCalendarActivity extends AppCompatActivity
             TemplateDialog dialog = new TemplateDialog();
             dialog.setCalendar(calendar);
             dialog.setTemplate(SuntimesCalendarSettings.loadPrefCalendarTemplate(context, calendar, calendarObj.defaultTemplate()));
+            dialog.setSupportedPatterns(calendarObj.supportedPatterns());
             dialog.setDialogListener(templateDialog_listener);
             dialog.show(getSupportFragmentManager(), DIALOGTAG_TEMPLATE + "_" + calendar);
         }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calendar/TemplatePatterns.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calendar/TemplatePatterns.java
@@ -48,6 +48,7 @@ public enum TemplatePatterns
 
     pattern_dist("%dist", R.string.help_pattern_dist),
     pattern_illum("%illum", R.string.help_pattern_illum),
+    pattern_phase("%phase", R.string.help_pattern_phase),
 
     pattern_percent("%%", R.string.help_pattern_percent);
 

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calendar/TemplatePatterns.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calendar/TemplatePatterns.java
@@ -73,29 +73,37 @@ public enum TemplatePatterns
         return context.getString(helpResource);
     }
 
-    public static String getAllHelpText(Context context)
+    public static String getAllHelpText(Context context) {
+        return getPatternHelpText(context, TemplatePatterns.values());
+    }
+    public static String getPatternHelpText(Context context, TemplatePatterns... patterns)
     {
         int c = 8;
         StringBuilder substitutionHelp = new StringBuilder();
 
-        TemplatePatterns[] patterns = TemplatePatterns.values();
         //substitutionHelp.append("<font face='monospace'>");
         for (int i=0; i<patterns.length; i++)
         {
-            String pattern = patterns[i].getPattern();
-            String patternHelp = patterns[i].getHelpText(context);
+            TemplatePatterns p = patterns[i];
+            String pattern = ((p != null) ? p.getPattern() : null);
+            if (pattern == null)
+            {
+                substitutionHelp.append("<br/>");
+                continue;
+            }
 
             substitutionHelp.append("<b>").append(pattern).append("</b>").append("&nbsp;");
             for (int j=0; j<(c-pattern.length()); j++) {
                 substitutionHelp.append("&nbsp;");
             }
+
+            String patternHelp = p.getHelpText(context);
             substitutionHelp.append(patternHelp)
                     .append("<br/>");
         }
         //substitutionHelp.append("</font");
         return substitutionHelp.toString();
     }
-
 
     public static ContentValues createContentValues(@Nullable ContentValues values, SuntimesCalendar calendar)
     {

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calendar/TemplatePatterns.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calendar/TemplatePatterns.java
@@ -39,6 +39,8 @@ public enum TemplatePatterns
     pattern_lel("%lel", R.string.help_pattern_lel),
 
     pattern_event("%M", R.string.help_pattern_event),
+    pattern_em("%em", R.string.help_pattern_altitude),
+
     pattern_eA("%eA", R.string.help_pattern_altitude),
     pattern_eZ("%eZ", R.string.help_pattern_azimuth),
     pattern_eD("%eD", R.string.help_pattern_declination),

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calendar/TemplatePatterns.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calendar/TemplatePatterns.java
@@ -45,9 +45,8 @@ public enum TemplatePatterns
     pattern_eR("%eR", R.string.help_pattern_rightascension),
 
     pattern_dist("%dist", R.string.help_pattern_dist),
-    pattern_illum("%i", R.string.help_pattern_illum),
-    pattern_phase("%p", R.string.help_pattern_phase),
-    
+    pattern_illum("%illum", R.string.help_pattern_illum),
+
     pattern_percent("%%", R.string.help_pattern_percent);
 
     private final String pattern;

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calendar/TemplatePatterns.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calendar/TemplatePatterns.java
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2023 Forrest Guice
+    Copyright (C) 2023-2024 Forrest Guice
     This file is part of SuntimesCalendars.
 
     SuntimesCalendars is free software: you can redistribute it and/or modify
@@ -32,13 +32,22 @@ public enum TemplatePatterns
     pattern_cal("%cal", R.string.help_pattern_cal),
     pattern_summary("%summary", R.string.help_pattern_summary),
     pattern_color("%color", R.string.help_pattern_color),
+
     pattern_loc("%loc", R.string.help_pattern_loc),
     pattern_lat("%lat", R.string.help_pattern_lat),
     pattern_lon("%lon", R.string.help_pattern_lon),
     pattern_lel("%lel", R.string.help_pattern_lel),
+
     pattern_event("%M", R.string.help_pattern_event),
+    pattern_eA("%eA", R.string.help_pattern_altitude),
+    pattern_eZ("%eZ", R.string.help_pattern_azimuth),
+    pattern_eD("%eD", R.string.help_pattern_declination),
+    pattern_eR("%eR", R.string.help_pattern_rightascension),
+
     pattern_dist("%dist", R.string.help_pattern_dist),
     pattern_illum("%i", R.string.help_pattern_illum),
+    pattern_phase("%p", R.string.help_pattern_phase),
+    
     pattern_percent("%%", R.string.help_pattern_percent);
 
     private final String pattern;

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/SuntimesCalendar.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/SuntimesCalendar.java
@@ -26,6 +26,7 @@ import com.forrestguice.suntimeswidget.calendar.SuntimesCalendarAdapter;
 import com.forrestguice.suntimeswidget.calendar.SuntimesCalendarSettings;
 import com.forrestguice.suntimeswidget.calendar.CalendarEventTemplate;
 import com.forrestguice.suntimeswidget.calendar.CalendarEventFlags;
+import com.forrestguice.suntimeswidget.calendar.TemplatePatterns;
 
 /**
  * @version 0.2.0
@@ -100,6 +101,10 @@ public interface SuntimesCalendar
      */
     CalendarEventTemplate defaultTemplate();
 
+    /**
+     * @return array of supported TemplatePatterns
+     */
+    TemplatePatterns[] supportedPatterns();
 
     /**
      * @return default strings

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/SuntimesCalendarTask.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/SuntimesCalendarTask.java
@@ -1,5 +1,5 @@
 /**
-    Copyright (C) 2018-2020 Forrest Guice
+    Copyright (C) 2018-2024 Forrest Guice
     This file is part of SuntimesCalendars.
 
     SuntimesCalendars is free software: you can redistribute it and/or modify
@@ -123,7 +123,7 @@ public class SuntimesCalendarTask extends SuntimesCalendarTaskBase
         }
 
         long[] window = getWindow();
-        boolean hasLocation = initLocation();
+        boolean hasLocation = queryConfig();
         boolean retValue = true;
 
         publishProgress(new SuntimesCalendarTaskProgress(1, 1000, notificationMsgUpdating));

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/SuntimesCalendarTask1.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/SuntimesCalendarTask1.java
@@ -200,7 +200,7 @@ public class SuntimesCalendarTask1 extends SuntimesCalendarTaskBase
         //Log.d(TAG, "Adding... startWindow: " + calendarWindow0 + " (" + window[0].get(Calendar.YEAR) + "), "
         //        + "endWindow: " + calendarWindow1 + " (" + window[1].get(Calendar.YEAR) + ")");
 
-        boolean retValue = initLocation();
+        boolean retValue = queryConfig();
         if (!retValue) {
             return false;
         }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/SuntimesCalendarTaskBase.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/SuntimesCalendarTaskBase.java
@@ -1,5 +1,5 @@
 /**
-    Copyright (C) 2018-2020 Forrest Guice
+    Copyright (C) 2018-2024 Forrest Guice
     This file is part of SuntimesCalendars.
 
     SuntimesCalendars is free software: you can redistribute it and/or modify
@@ -30,10 +30,18 @@ import com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContrac
 import com.forrestguice.suntimeswidget.calendar.SuntimesCalendarAdapter;
 import com.forrestguice.suntimeswidget.calendar.SuntimesCalendarDescriptor;
 import com.forrestguice.suntimeswidget.calendar.SuntimesCalendarSettings;
+import com.forrestguice.suntimeswidget.calendar.ui.Utils;
 
 import java.lang.ref.WeakReference;
 import java.util.Calendar;
 import java.util.HashMap;
+
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract.COLUMN_CONFIG_ALTITUDE;
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract.COLUMN_CONFIG_LATITUDE;
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract.COLUMN_CONFIG_LENGTH_UNITS;
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract.COLUMN_CONFIG_LOCATION;
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract.COLUMN_CONFIG_LONGITUDE;
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract.COLUMN_CONFIG_PROVIDER_VERSION_CODE;
 
 @SuppressWarnings("Convert2Diamond")
 public abstract class SuntimesCalendarTaskBase extends AsyncTask<SuntimesCalendarTaskItem, SuntimesCalendarTaskProgress, Boolean>
@@ -51,6 +59,7 @@ public abstract class SuntimesCalendarTaskBase extends AsyncTask<SuntimesCalenda
     protected String config_location_latitude = "";
     protected String config_location_longitude = "";
     protected String config_location_altitude = "";
+    protected String config_provider_length_units = Utils.LengthUnit.METRIC.name();
 
     protected long lastSync = -1;
     protected String lastError = null;
@@ -116,14 +125,19 @@ public abstract class SuntimesCalendarTaskBase extends AsyncTask<SuntimesCalenda
         return flag_clear;
     }
 
-    protected boolean initLocation()
+    /**
+     * init location and other settings defined by Suntimes
+     * @return
+     */
+    protected boolean queryConfig()
     {
         Context context = contextRef.get();
         ContentResolver resolver = (context == null ? null : context.getContentResolver());
         if (resolver != null)
         {
             Uri configUri = Uri.parse("content://" + CalculatorProviderContract.AUTHORITY + "/" + CalculatorProviderContract.QUERY_CONFIG);
-            String[] configProjection = new String[]{CalculatorProviderContract.COLUMN_CONFIG_LOCATION, CalculatorProviderContract.COLUMN_CONFIG_LATITUDE, CalculatorProviderContract.COLUMN_CONFIG_LONGITUDE, CalculatorProviderContract.COLUMN_CONFIG_ALTITUDE, CalculatorProviderContract.COLUMN_CONFIG_PROVIDER_VERSION_CODE};
+            String[] configProjection = new String[] { COLUMN_CONFIG_LOCATION, COLUMN_CONFIG_LATITUDE, COLUMN_CONFIG_LONGITUDE, COLUMN_CONFIG_ALTITUDE,
+                    COLUMN_CONFIG_LENGTH_UNITS, COLUMN_CONFIG_PROVIDER_VERSION_CODE };
 
             try {
                 Cursor configCursor = resolver.query(configUri, configProjection, null, null, null);
@@ -131,11 +145,12 @@ public abstract class SuntimesCalendarTaskBase extends AsyncTask<SuntimesCalenda
                 {
                     configCursor.moveToFirst();
                     for (int i = 0; i < configProjection.length; i++) {
-                        config_location_name = configCursor.getString(configCursor.getColumnIndex(CalculatorProviderContract.COLUMN_CONFIG_LOCATION));
-                        config_location_latitude = configCursor.getString(configCursor.getColumnIndex(CalculatorProviderContract.COLUMN_CONFIG_LATITUDE));
-                        config_location_longitude = configCursor.getString(configCursor.getColumnIndex(CalculatorProviderContract.COLUMN_CONFIG_LONGITUDE));
-                        config_location_altitude = configCursor.getString(configCursor.getColumnIndex(CalculatorProviderContract.COLUMN_CONFIG_ALTITUDE));
-                        config_provider_version = configCursor.getInt(configCursor.getColumnIndex(CalculatorProviderContract.COLUMN_CONFIG_PROVIDER_VERSION_CODE));
+                        config_location_name = configCursor.getString(configCursor.getColumnIndex(COLUMN_CONFIG_LOCATION));
+                        config_location_latitude = configCursor.getString(configCursor.getColumnIndex(COLUMN_CONFIG_LATITUDE));
+                        config_location_longitude = configCursor.getString(configCursor.getColumnIndex(COLUMN_CONFIG_LONGITUDE));
+                        config_location_altitude = configCursor.getString(configCursor.getColumnIndex(COLUMN_CONFIG_ALTITUDE));
+                        config_provider_version = configCursor.getInt(configCursor.getColumnIndex(COLUMN_CONFIG_PROVIDER_VERSION_CODE));
+                        config_provider_length_units = configCursor.getString(configCursor.getColumnIndex(COLUMN_CONFIG_LENGTH_UNITS));
                     }
                     configCursor.close();
                     return true;
@@ -158,6 +173,10 @@ public abstract class SuntimesCalendarTaskBase extends AsyncTask<SuntimesCalenda
     }
     public String[] getLocation() {
         return new String[] { config_location_name, config_location_latitude, config_location_longitude, config_location_altitude };
+    }
+
+    public String getLengthUnits() {
+        return config_provider_length_units;
     }
 
     public int getProviderVersion() {

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/DaylightCalendar.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/DaylightCalendar.java
@@ -140,6 +140,7 @@ public class DaylightCalendar extends SuntimesCalendarBase implements SuntimesCa
 
                 int i_eZ = -1, i_eA = -1, i_eR = -1, i_eD = -1;
                 boolean containsPattern_eZ, containsPattern_eA, containsPattern_eR, containsPattern_eD;
+                boolean containsPattern_em = template.containsPattern(TemplatePatterns.pattern_em);
 
                 int j = 3;
                 ArrayList<String> projection0 = new ArrayList<>(Arrays.asList(COLUMN_SUN_ACTUAL_RISE, COLUMN_SUN_NOON, COLUMN_SUN_ACTUAL_SET));
@@ -215,6 +216,9 @@ public class DaylightCalendar extends SuntimesCalendarBase implements SuntimesCa
                                 }
                                 if (containsPattern_eD) {
                                     data.put(TemplatePatterns.pattern_eD.getPattern(), Utils.formatAsDeclination(cursor.getDouble(i + i_eD), 1));
+                                }
+                                if (containsPattern_em) {
+                                    data.put(TemplatePatterns.pattern_em.getPattern(), eventTime.getTimeInMillis());
                                 }
 
                                 eventValues.add(adapter.createEventContentValues(calendarID, template.getTitle(data), template.getDesc(data), template.getLocation(data), eventTime));

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/DaylightCalendar.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/DaylightCalendar.java
@@ -37,10 +37,19 @@ import com.forrestguice.suntimeswidget.calendar.TemplatePatterns;
 import com.forrestguice.suntimeswidget.calendar.task.SuntimesCalendar;
 import com.forrestguice.suntimeswidget.calendar.task.SuntimesCalendarTask;
 import com.forrestguice.suntimeswidget.calendar.task.SuntimesCalendarTaskProgress;
+import com.forrestguice.suntimeswidget.calendar.ui.Utils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
+
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract.COLUMN_SUN_ACTUAL_RISE;
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract.COLUMN_SUN_ACTUAL_SET;
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract.COLUMN_SUN_NOON;
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract._POSITION_ALT;
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract._POSITION_AZ;
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract._POSITION_DEC;
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract._POSITION_RA;
 
 @SuppressWarnings("Convert2Diamond")
 public class DaylightCalendar extends SuntimesCalendarBase implements SuntimesCalendar
@@ -58,7 +67,7 @@ public class DaylightCalendar extends SuntimesCalendarBase implements SuntimesCa
 
     @Override
     public CalendarEventTemplate defaultTemplate() {
-        return new CalendarEventTemplate("%M", "%M @ %loc", "%loc");
+        return new CalendarEventTemplate("%M", "%M @ %loc\n%eZ, %eA", "%loc");
     }
 
     @Override
@@ -85,6 +94,7 @@ public class DaylightCalendar extends SuntimesCalendarBase implements SuntimesCa
     public void init(@NonNull Context context, @NonNull SuntimesCalendarSettings settings)
     {
         super.init(context, settings);
+        Utils.initDisplayStrings(context);
 
         calendarTitle = context.getString(resID_calendarTitle);
         calendarSummary = context.getString(resID_calendarSummary);
@@ -115,8 +125,49 @@ public class DaylightCalendar extends SuntimesCalendarBase implements SuntimesCa
             ContentResolver resolver = (context == null ? null : context.getContentResolver());
             if (resolver != null)
             {
+                CalendarEventTemplate template = SuntimesCalendarSettings.loadPrefCalendarTemplate(context, calendarName, defaultTemplate());
+                boolean[] flags = SuntimesCalendarSettings.loadPrefCalendarFlags(context, calendarName, defaultFlags()).getValues();
+                String[] strings = SuntimesCalendarSettings.loadPrefCalendarStrings(context, calendarName, defaultStrings()).getValues();
+
+                int i_eZ = -1, i_eA = -1, i_eR = -1, i_eD = -1;
+                boolean containsPattern_eZ, containsPattern_eA, containsPattern_eR, containsPattern_eD;
+
+                int j = 3;
+                ArrayList<String> projection0 = new ArrayList<>(Arrays.asList(COLUMN_SUN_ACTUAL_RISE, COLUMN_SUN_NOON, COLUMN_SUN_ACTUAL_SET));
+                if (containsPattern_eZ = template.containsPattern(TemplatePatterns.pattern_eZ)) {
+                    i_eZ  = j;
+                    projection0.add(COLUMN_SUN_ACTUAL_RISE + _POSITION_AZ);
+                    projection0.add(COLUMN_SUN_NOON + _POSITION_AZ);
+                    projection0.add(COLUMN_SUN_ACTUAL_SET + _POSITION_AZ);
+                    j += 3;
+                }
+                if (containsPattern_eA = template.containsPattern(TemplatePatterns.pattern_eA))
+                {
+                    i_eA  = j;
+                    projection0.add(COLUMN_SUN_ACTUAL_RISE + _POSITION_ALT);
+                    projection0.add(COLUMN_SUN_NOON + _POSITION_ALT);
+                    projection0.add(COLUMN_SUN_ACTUAL_SET + _POSITION_ALT);
+                    j += 3;
+                }
+                if (containsPattern_eR = template.containsPattern(TemplatePatterns.pattern_eR))
+                {
+                    i_eR  = j;
+                    projection0.add(COLUMN_SUN_ACTUAL_RISE + _POSITION_RA);
+                    projection0.add(COLUMN_SUN_NOON + _POSITION_RA);
+                    projection0.add(COLUMN_SUN_ACTUAL_SET + _POSITION_RA);
+                    j += 3;
+                }
+                if (containsPattern_eD = template.containsPattern(TemplatePatterns.pattern_eD))
+                {
+                    i_eD  = j;
+                    projection0.add(COLUMN_SUN_ACTUAL_RISE + _POSITION_DEC);
+                    projection0.add(COLUMN_SUN_NOON + _POSITION_DEC);
+                    projection0.add(COLUMN_SUN_ACTUAL_SET + _POSITION_DEC);
+                    j += 3;
+                }
+                String[] projection = projection0.toArray(new String[0]);
+
                 Uri uri = Uri.parse("content://" + CalculatorProviderContract.AUTHORITY + "/" + CalculatorProviderContract.QUERY_SUN + "/" + window[0] + "-" + window[1]);
-                String[] projection = new String[] { CalculatorProviderContract.COLUMN_SUN_ACTUAL_RISE, CalculatorProviderContract.COLUMN_SUN_NOON, CalculatorProviderContract.COLUMN_SUN_ACTUAL_SET };
                 Cursor cursor = resolver.query(uri, projection, null, null, null);
                 if (cursor != null)
                 {
@@ -129,9 +180,6 @@ public class DaylightCalendar extends SuntimesCalendarBase implements SuntimesCa
                     SuntimesCalendarTaskProgress progress = task.createProgressObj(c, totalProgress, progressTitle);
                     task.publishProgress(progress0, progress);
 
-                    boolean[] flags = SuntimesCalendarSettings.loadPrefCalendarFlags(context, calendarName, defaultFlags()).getValues();
-                    String[] strings = SuntimesCalendarSettings.loadPrefCalendarStrings(context, calendarName, defaultStrings()).getValues();
-                    CalendarEventTemplate template = SuntimesCalendarSettings.loadPrefCalendarTemplate(context, calendarName, defaultTemplate());
                     ContentValues data = TemplatePatterns.createContentValues(null, this);
                     data = TemplatePatterns.createContentValues(data, task.getLocation());
 
@@ -139,13 +187,27 @@ public class DaylightCalendar extends SuntimesCalendarBase implements SuntimesCa
                     cursor.moveToFirst();
                     while (!cursor.isAfterLast() && !task.isCancelled())
                     {
-                        for (int i=0; i<projection.length; i++)
+                        for (int i=0; i<3; i++)
                         {
                             if (flags[i] && !cursor.isNull(i))
                             {
                                 Calendar eventTime = Calendar.getInstance();
                                 eventTime.setTimeInMillis(cursor.getLong(i));
                                 data.put(TemplatePatterns.pattern_event.getPattern(), strings[i]);
+
+                                if (containsPattern_eZ) {
+                                    data.put(TemplatePatterns.pattern_eZ.getPattern(), Utils.formatAsDirection(cursor.getDouble(i + i_eZ), 2));
+                                }
+                                if (containsPattern_eA) {
+                                    data.put(TemplatePatterns.pattern_eA.getPattern(), Utils.formatAsElevation(cursor.getDouble(i + i_eA), 2));
+                                }
+                                if (containsPattern_eR) {
+                                    data.put(TemplatePatterns.pattern_eR.getPattern(), Utils.formatAsRightAscension(cursor.getDouble(i + i_eR), 1));
+                                }
+                                if (containsPattern_eD) {
+                                    data.put(TemplatePatterns.pattern_eD.getPattern(), Utils.formatAsDeclination(cursor.getDouble(i + i_eD), 1));
+                                }
+
                                 eventValues.add(adapter.createEventContentValues(calendarID, template.getTitle(data), template.getDesc(data), template.getLocation(data), eventTime));
                                 //Log.d("DEBUG", "create event: " + strings[i] + " at " + eventTime.toString());
                             }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/DaylightCalendar.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/DaylightCalendar.java
@@ -71,6 +71,16 @@ public class DaylightCalendar extends SuntimesCalendarBase implements SuntimesCa
     }
 
     @Override
+    public TemplatePatterns[] supportedPatterns()
+    {
+        return new TemplatePatterns[] {
+                TemplatePatterns.pattern_event, TemplatePatterns.pattern_eZ, TemplatePatterns.pattern_eA, TemplatePatterns.pattern_eD, TemplatePatterns.pattern_eR, null,
+                TemplatePatterns.pattern_loc, TemplatePatterns.pattern_lat, TemplatePatterns.pattern_lon, TemplatePatterns.pattern_lel, null,
+                TemplatePatterns.pattern_cal, TemplatePatterns.pattern_summary, TemplatePatterns.pattern_color, TemplatePatterns.pattern_percent
+        };
+    }
+
+    @Override
     public CalendarEventStrings defaultStrings() {
         return new CalendarEventStrings(daylightStrings);
     }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/DaylightCalendar.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/DaylightCalendar.java
@@ -104,7 +104,6 @@ public class DaylightCalendar extends SuntimesCalendarBase implements SuntimesCa
     public void init(@NonNull Context context, @NonNull SuntimesCalendarSettings settings)
     {
         super.init(context, settings);
-        Utils.initDisplayStrings(context);
 
         calendarTitle = context.getString(resID_calendarTitle);
         calendarSummary = context.getString(resID_calendarSummary);

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/MoonapsisCalendar.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/MoonapsisCalendar.java
@@ -63,6 +63,18 @@ public class MoonapsisCalendar extends MoonCalendarBase implements SuntimesCalen
     }
 
     @Override
+    public TemplatePatterns[] supportedPatterns()
+    {
+        return new TemplatePatterns[] {
+                TemplatePatterns.pattern_event, null, //TemplatePatterns.pattern_eZ, TemplatePatterns.pattern_eA, TemplatePatterns.pattern_eD, TemplatePatterns.pattern_eR, null,  // TODO: position patterns
+                //TemplatePatterns.pattern_illum,    // TODO: illum pattern
+                TemplatePatterns.pattern_dist, null,
+                TemplatePatterns.pattern_loc, TemplatePatterns.pattern_lat, TemplatePatterns.pattern_lon, TemplatePatterns.pattern_lel, null,
+                TemplatePatterns.pattern_cal, TemplatePatterns.pattern_summary, TemplatePatterns.pattern_color, TemplatePatterns.pattern_percent
+        };
+    }
+
+    @Override
     public CalendarEventStrings defaultStrings() {
         return new CalendarEventStrings(apsisStrings);
     }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/MoonapsisCalendar.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/MoonapsisCalendar.java
@@ -1,5 +1,5 @@
 /**
-    Copyright (C) 2018-2023 Forrest Guice
+    Copyright (C) 2018-2024 Forrest Guice
     This file is part of SuntimesCalendars.
 
     SuntimesCalendars is free software: you can redistribute it and/or modify
@@ -38,6 +38,7 @@ import com.forrestguice.suntimeswidget.calendar.task.SuntimesCalendarTask;
 import com.forrestguice.suntimeswidget.calendar.task.SuntimesCalendarTaskProgress;
 import com.forrestguice.suntimeswidget.calendar.CalendarEventTemplate;
 import com.forrestguice.suntimeswidget.calendar.TemplatePatterns;
+import com.forrestguice.suntimeswidget.calendar.ui.Utils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -198,8 +199,10 @@ public class MoonapsisCalendar extends MoonCalendarBase implements SuntimesCalen
                                 Calendar eventTime = Calendar.getInstance();
                                 eventTime.setTimeInMillis(cursor.getLong(i));
                                 double distance = lookupMoonDistance(context, resolver, eventTime.getTimeInMillis());
+                                String distanceString = ((distance > 0) ? Utils.formatAsDistance(task.getLengthUnits(), distance, 1) : "");
+
                                 data.put(TemplatePatterns.pattern_event.getPattern(), strings[i]);
-                                data.put(TemplatePatterns.pattern_dist.getPattern(), ((distance > 0) ? context.getString(R.string.distance_format, formatDistanceString(distance)) : ""));
+                                data.put(TemplatePatterns.pattern_dist.getPattern(), distanceString);
                                 eventValues.add(adapter.createEventContentValues(calendarID, template.getTitle(data), template.getDesc(data), template.getLocation(data), eventTime));
                             }
                             date.setTimeInMillis(cursor.getLong(0) + (60 * 1000));  // advance to next cycle

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/MoonphaseCalendar.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/MoonphaseCalendar.java
@@ -1,5 +1,5 @@
 /**
-    Copyright (C) 2018-2023 Forrest Guice
+    Copyright (C) 2018-2024 Forrest Guice
     This file is part of SuntimesCalendars.
 
     SuntimesCalendars is free software: you can redistribute it and/or modify
@@ -38,6 +38,7 @@ import com.forrestguice.suntimeswidget.calendar.task.SuntimesCalendarTask;
 import com.forrestguice.suntimeswidget.calendar.task.SuntimesCalendarTaskProgress;
 import com.forrestguice.suntimeswidget.calendar.CalendarEventTemplate;
 import com.forrestguice.suntimeswidget.calendar.TemplatePatterns;
+import com.forrestguice.suntimeswidget.calendar.ui.Utils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -203,7 +204,7 @@ public class MoonphaseCalendar extends MoonCalendarBase
 
                             String[] eventStrings = getPhaseStrings(i, distance, strings);
                             data.put(TemplatePatterns.pattern_event.getPattern(), eventStrings[i]);
-                            data.put(TemplatePatterns.pattern_dist.getPattern(), ((distance > 0) ? context.getString(R.string.distance_format, formatDistanceString(distance)) : ""));
+                            data.put(TemplatePatterns.pattern_dist.getPattern(), ((distance > 0) ? Utils.formatAsDistance(task.getLengthUnits(), distance, 2) : ""));
 
                             Calendar eventTime = Calendar.getInstance();
                             eventTime.setTimeInMillis(cursor.getLong(i));

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/MoonphaseCalendar.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/MoonphaseCalendar.java
@@ -44,6 +44,15 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract.COLUMN_MOON_FIRST;
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract.COLUMN_MOON_FIRST_DISTANCE;
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract.COLUMN_MOON_FULL;
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract.COLUMN_MOON_FULL_DISTANCE;
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract.COLUMN_MOON_NEW;
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract.COLUMN_MOON_NEW_DISTANCE;
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract.COLUMN_MOON_THIRD;
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract.COLUMN_MOON_THIRD_DISTANCE;
+
 @SuppressWarnings("Convert2Diamond")
 public class MoonphaseCalendar extends MoonCalendarBase
 {
@@ -155,15 +164,6 @@ public class MoonphaseCalendar extends MoonCalendarBase
             adapter.createCalendar(calendarName, calendarTitle, calendarColor);
         } else return false;
 
-        String[] projection = new String[] {    // indices 0-3 should contain ordered phases!
-                CalculatorProviderContract.COLUMN_MOON_NEW,
-                CalculatorProviderContract.COLUMN_MOON_FIRST,
-                CalculatorProviderContract.COLUMN_MOON_FULL,
-                CalculatorProviderContract.COLUMN_MOON_THIRD,
-                CalculatorProviderContract.COLUMN_MOON_NEW_DISTANCE,  // use indices 4+ for other data
-                CalculatorProviderContract.COLUMN_MOON_FULL_DISTANCE
-        };
-
         long calendarID = adapter.queryCalendarID(calendarName);
         if (calendarID != -1)
         {
@@ -171,7 +171,30 @@ public class MoonphaseCalendar extends MoonCalendarBase
             ContentResolver resolver = (context == null ? null : context.getContentResolver());
             if (resolver != null)
             {
+                CalendarEventTemplate template = SuntimesCalendarSettings.loadPrefCalendarTemplate(context, calendarName, defaultTemplate());
+                boolean[] flags = SuntimesCalendarSettings.loadPrefCalendarFlags(context, calendarName, defaultFlags()).getValues();
+                String[] strings = SuntimesCalendarSettings.loadPrefCalendarStrings(context, calendarName, defaultStrings()).getValues();
+
+                ArrayList<String> projection0 = new ArrayList<>(Arrays.asList(
+                        COLUMN_MOON_NEW, COLUMN_MOON_FIRST,      // 0, 1
+                        COLUMN_MOON_FULL, COLUMN_MOON_THIRD));   // 2, 3
+
+                int i_dist = -1;
+                boolean containsPattern_dist = template.containsPattern(TemplatePatterns.pattern_dist);
+
+                int j = 4;
+                if (containsPattern_dist)
+                {
+                    i_dist = j;
+                    projection0.add(COLUMN_MOON_NEW_DISTANCE);
+                    projection0.add(COLUMN_MOON_FIRST_DISTANCE);
+                    projection0.add(COLUMN_MOON_FULL_DISTANCE);
+                    projection0.add(COLUMN_MOON_THIRD_DISTANCE);
+                    j += 4;
+                }
+
                 Uri uri = Uri.parse("content://" + CalculatorProviderContract.AUTHORITY + "/" + CalculatorProviderContract.QUERY_MOONPHASE + "/" + window[0] + "-" + window[1]);
+                String[] projection = projection0.toArray(new String[0]);
                 Cursor cursor = resolver.query(uri, projection, null, null, null);
                 if (cursor != null)
                 {
@@ -180,9 +203,6 @@ public class MoonphaseCalendar extends MoonCalendarBase
                     SuntimesCalendarTaskProgress progress = task.createProgressObj(c, totalProgress, calendarTitle);
                     task.publishProgress(progress0, progress);
 
-                    boolean[] flags = SuntimesCalendarSettings.loadPrefCalendarFlags(context, calendarName, defaultFlags()).getValues();
-                    String[] strings = SuntimesCalendarSettings.loadPrefCalendarStrings(context, calendarName, defaultStrings()).getValues();
-                    CalendarEventTemplate template = SuntimesCalendarSettings.loadPrefCalendarTemplate(context, calendarName, defaultTemplate());
                     ContentValues data = TemplatePatterns.createContentValues(null, this);
                     data = TemplatePatterns.createContentValues(data, task.getLocation());
 
@@ -196,12 +216,7 @@ public class MoonphaseCalendar extends MoonCalendarBase
                                 continue;
                             }
 
-                            double distance = -1;
-                            if (i == 0 || i == 2)  // new moon || full moon
-                            {
-                                distance = cursor.getDouble(i == 0 ? 4 : 5);
-                            }
-
+                            double distance = cursor.getDouble(i + i_dist);
                             String[] eventStrings = getPhaseStrings(i, distance, strings);
                             data.put(TemplatePatterns.pattern_event.getPattern(), eventStrings[i]);
                             data.put(TemplatePatterns.pattern_dist.getPattern(), ((distance > 0) ? Utils.formatAsDistance(task.getLengthUnits(), distance, 2) : ""));

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/MoonphaseCalendar.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/MoonphaseCalendar.java
@@ -68,6 +68,18 @@ public class MoonphaseCalendar extends MoonCalendarBase
     }
 
     @Override
+    public TemplatePatterns[] supportedPatterns()
+    {
+        return new TemplatePatterns[] {
+                TemplatePatterns.pattern_event, null, // TemplatePatterns.pattern_eZ, TemplatePatterns.pattern_eA, TemplatePatterns.pattern_eD, TemplatePatterns.pattern_eR, null,   // TODO: position patterns
+                //TemplatePatterns.pattern_illum,  // TODO: illum pattern
+                TemplatePatterns.pattern_dist, null,
+                TemplatePatterns.pattern_loc, TemplatePatterns.pattern_lat, TemplatePatterns.pattern_lon, TemplatePatterns.pattern_lel, null,
+                TemplatePatterns.pattern_cal, TemplatePatterns.pattern_summary, TemplatePatterns.pattern_color, TemplatePatterns.pattern_percent
+        };
+    }
+
+    @Override
     public CalendarEventStrings defaultStrings() {
         return new CalendarEventStrings(phaseStrings[0], phaseStrings[1], phaseStrings[2], phaseStrings[3],   // 0-3 normal phases
                 phaseStrings1[0], phaseStrings1[2],                                                           // 4,5 super moon

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/MoonriseCalendar.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/MoonriseCalendar.java
@@ -73,7 +73,7 @@ public class MoonriseCalendar extends MoonCalendarBase implements SuntimesCalend
 
     @Override
     public CalendarEventTemplate defaultTemplate() {
-        return new CalendarEventTemplate("%M", "%M @ %loc\n%illum", "%loc");
+        return new CalendarEventTemplate("%M", "%M @ %loc\n%eZ, %illum", "%loc");
     }
 
     @Override

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/MoonriseCalendar.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/MoonriseCalendar.java
@@ -136,6 +136,7 @@ public class MoonriseCalendar extends MoonCalendarBase implements SuntimesCalend
 
                 int i_eZ = -1, i_eA = -1, i_eR = -1, i_eD = -1, i_illum = -1, i_dist = -1;
                 boolean containsPattern_eZ, containsPattern_eA, containsPattern_eR, containsPattern_eD, containsPattern_dist, containsPattern_illum;
+                boolean containsPattern_em = template.containsPattern(TemplatePatterns.pattern_em);
 
                 int j = 2;
                 ArrayList<String> projection0 = new ArrayList<>(Arrays.asList(COLUMN_MOON_RISE, COLUMN_MOON_SET));
@@ -227,6 +228,9 @@ public class MoonriseCalendar extends MoonCalendarBase implements SuntimesCalend
                                 }
                                 if (containsPattern_illum) {
                                     data.put(TemplatePatterns.pattern_illum.getPattern(), Utils.formatAsPercent(cursor.getDouble(i + i_illum), 1));
+                                }
+                                if (containsPattern_em) {
+                                    data.put(TemplatePatterns.pattern_em.getPattern(), eventTime.getTimeInMillis());
                                 }
                                 //desc = context.getString(R.string.event_at_format, moonStrings[i], context.getString(R.string.location_format_short, config_location_name, config_location_latitude, config_location_longitude));
                                 //desc = context.getString(R.string.event_at_format, moonStrings[i], location[0]);

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/MoonriseCalendar.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/MoonriseCalendar.java
@@ -1,5 +1,5 @@
 /**
-    Copyright (C) 2018-2023 Forrest Guice
+    Copyright (C) 2018-2024 Forrest Guice
     This file is part of SuntimesCalendars.
 
     SuntimesCalendars is free software: you can redistribute it and/or modify
@@ -258,7 +258,7 @@ public class MoonriseCalendar extends MoonCalendarBase implements SuntimesCalend
                                     data.put(TemplatePatterns.pattern_eD.getPattern(), Utils.formatAsDeclination(cursor.getDouble(i + i_eD), 1));
                                 }
                                 if (containsPattern_dist) {
-                                    data.put(TemplatePatterns.pattern_dist.getPattern(), Utils.formatAsDistanceKm(cursor.getDouble(i + i_dist), 1));   // TODO: length units
+                                    data.put(TemplatePatterns.pattern_dist.getPattern(), Utils.formatAsDistance(task.getLengthUnits(), cursor.getDouble(i + i_dist), 1));
                                 }
                                 if (containsPattern_illum) {
                                     data.put(TemplatePatterns.pattern_illum.getPattern(), Utils.formatAsPercent(cursor.getDouble(i + i_illum), 1));

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/MoonriseCalendar.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/MoonriseCalendar.java
@@ -37,10 +37,25 @@ import com.forrestguice.suntimeswidget.calendar.task.SuntimesCalendarTask;
 import com.forrestguice.suntimeswidget.calendar.task.SuntimesCalendarTaskProgress;
 import com.forrestguice.suntimeswidget.calendar.CalendarEventTemplate;
 import com.forrestguice.suntimeswidget.calendar.TemplatePatterns;
+import com.forrestguice.suntimeswidget.calendar.ui.Utils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
+
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract.COLUMN_MOON_RISE;
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract.COLUMN_MOON_RISE_DISTANCE;
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract.COLUMN_MOON_RISE_ILLUM;
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract.COLUMN_MOON_SET;
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract.COLUMN_MOON_SET_DISTANCE;
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract.COLUMN_MOON_SET_ILLUM;
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract.COLUMN_SUN_ACTUAL_RISE;
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract.COLUMN_SUN_ACTUAL_SET;
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract.COLUMN_SUN_NOON;
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract._POSITION_ALT;
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract._POSITION_AZ;
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract._POSITION_DEC;
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract._POSITION_RA;
 
 @SuppressWarnings("Convert2Diamond")
 public class MoonriseCalendar extends MoonCalendarBase implements SuntimesCalendar
@@ -58,7 +73,7 @@ public class MoonriseCalendar extends MoonCalendarBase implements SuntimesCalend
 
     @Override
     public CalendarEventTemplate defaultTemplate() {
-        return new CalendarEventTemplate("%M", "%M @ %loc", "%loc");
+        return new CalendarEventTemplate("%M", "%M @ %loc\n%illum", "%loc");
     }
 
     @Override
@@ -115,56 +130,123 @@ public class MoonriseCalendar extends MoonCalendarBase implements SuntimesCalend
             ContentResolver resolver = (context == null ? null : context.getContentResolver());
             if (resolver != null)
             {
+                boolean[] flags = SuntimesCalendarSettings.loadPrefCalendarFlags(context, calendarName, defaultFlags()).getValues();
+                String[] strings = SuntimesCalendarSettings.loadPrefCalendarStrings(context, calendarName, defaultStrings()).getValues();
+                CalendarEventTemplate template = SuntimesCalendarSettings.loadPrefCalendarTemplate(context, calendarName, defaultTemplate());
+
+                int i_eZ = -1, i_eA = -1, i_eR = -1, i_eD = -1, i_illum = -1, i_dist = -1;
+                boolean containsPattern_eZ, containsPattern_eA, containsPattern_eR, containsPattern_eD, containsPattern_dist, containsPattern_illum;
+
+                int j = 2;
+                ArrayList<String> projection0 = new ArrayList<>(Arrays.asList(COLUMN_MOON_RISE, COLUMN_MOON_SET));
+                if (containsPattern_eZ = template.containsPattern(TemplatePatterns.pattern_eZ)) {
+                    i_eZ  = j;
+                    projection0.add(COLUMN_MOON_RISE + _POSITION_AZ);
+                    projection0.add(COLUMN_MOON_SET + _POSITION_AZ);
+                    j += 2;
+                }
+                if (containsPattern_eA = template.containsPattern(TemplatePatterns.pattern_eA))
+                {
+                    i_eA  = j;
+                    projection0.add(COLUMN_MOON_RISE + _POSITION_ALT);
+                    projection0.add(COLUMN_MOON_SET + _POSITION_ALT);
+                    j += 2;
+                }
+                if (containsPattern_eR = template.containsPattern(TemplatePatterns.pattern_eR))
+                {
+                    i_eR  = j;
+                    projection0.add(COLUMN_MOON_RISE + _POSITION_RA);
+                    projection0.add(COLUMN_MOON_SET + _POSITION_RA);
+                    j += 2;
+                }
+                if (containsPattern_eD = template.containsPattern(TemplatePatterns.pattern_eD))
+                {
+                    i_eD  = j;
+                    projection0.add(COLUMN_MOON_RISE + _POSITION_DEC);
+                    projection0.add(COLUMN_MOON_SET + _POSITION_DEC);
+                    j += 2;
+                }
+                if (containsPattern_dist = template.containsPattern(TemplatePatterns.pattern_dist))
+                {
+                    i_dist  = j;
+                    projection0.add(COLUMN_MOON_RISE_DISTANCE);
+                    projection0.add(COLUMN_MOON_SET_DISTANCE);
+                    j += 2;
+                }
+                if (containsPattern_illum = template.containsPattern(TemplatePatterns.pattern_illum))
+                {
+                    i_illum  = j;
+                    projection0.add(COLUMN_MOON_RISE_ILLUM);
+                    projection0.add(COLUMN_MOON_SET_ILLUM);
+                    j += 2;
+                }
+                String[] projection = projection0.toArray(new String[0]);
+
                 Uri moonUri = Uri.parse("content://" + CalculatorProviderContract.AUTHORITY + "/" + CalculatorProviderContract.QUERY_MOON + "/" + window[0] + "-" + window[1]);
-                String[] moonProjection = new String[] { CalculatorProviderContract.COLUMN_MOON_RISE, CalculatorProviderContract.COLUMN_MOON_SET };
-                Cursor moonCursor = resolver.query(moonUri, moonProjection, null, null, null);
-                if (moonCursor != null)
+                Cursor cursor = resolver.query(moonUri, projection, null, null, null);
+                if (cursor != null)
                 {
                     String[] location = task.getLocation();
                     settings.saveCalendarNote(context, calendarName, SuntimesCalendarSettings.NOTE_LOCATION_NAME, location[0]);
 
                     int c = 0;
-                    int totalProgress = moonCursor.getCount();
+                    int totalProgress = cursor.getCount();
                     String progressTitle = context.getString(R.string.summarylist_format, calendarTitle, location[0]);
                     SuntimesCalendarTaskProgress progress = task.createProgressObj(c, totalProgress, progressTitle);
                     task.publishProgress(progress0, progress);
 
-                    boolean[] flags = SuntimesCalendarSettings.loadPrefCalendarFlags(context, calendarName, defaultFlags()).getValues();
-                    String[] strings = SuntimesCalendarSettings.loadPrefCalendarStrings(context, calendarName, defaultStrings()).getValues();
-                    CalendarEventTemplate template = SuntimesCalendarSettings.loadPrefCalendarTemplate(context, calendarName, defaultTemplate());
                     ContentValues data = TemplatePatterns.createContentValues(null, this);
                     data = TemplatePatterns.createContentValues(data, task.getLocation());
 
                     ArrayList<ContentValues> eventValues = new ArrayList<>();
-                    moonCursor.moveToFirst();
-                    while (!moonCursor.isAfterLast() && !task.isCancelled())
+                    cursor.moveToFirst();
+                    while (!cursor.isAfterLast() && !task.isCancelled())
                     {
-                        for (int i=0; i<moonProjection.length; i++)
+                        for (int i=0; i<2; i++)
                         {
-                            if (flags[i] && !moonCursor.isNull(i))
+                            if (flags[i] && !cursor.isNull(i))
                             {
                                 Calendar eventTime = Calendar.getInstance();
-                                eventTime.setTimeInMillis(moonCursor.getLong(i));
+                                eventTime.setTimeInMillis(cursor.getLong(i));
                                 data.put(TemplatePatterns.pattern_event.getPattern(), strings[i]);
+
+                                if (containsPattern_eZ) {
+                                    data.put(TemplatePatterns.pattern_eZ.getPattern(), Utils.formatAsDirection(cursor.getDouble(i + i_eZ), 2));
+                                }
+                                if (containsPattern_eA) {
+                                    data.put(TemplatePatterns.pattern_eA.getPattern(), Utils.formatAsElevation(cursor.getDouble(i + i_eA), 2));
+                                }
+                                if (containsPattern_eR) {
+                                    data.put(TemplatePatterns.pattern_eR.getPattern(), Utils.formatAsRightAscension(cursor.getDouble(i + i_eR), 1));
+                                }
+                                if (containsPattern_eD) {
+                                    data.put(TemplatePatterns.pattern_eD.getPattern(), Utils.formatAsDeclination(cursor.getDouble(i + i_eD), 1));
+                                }
+                                if (containsPattern_dist) {
+                                    data.put(TemplatePatterns.pattern_dist.getPattern(), Utils.formatAsDistanceKm(cursor.getDouble(i + i_dist), 1));   // TODO: length units
+                                }
+                                if (containsPattern_illum) {
+                                    data.put(TemplatePatterns.pattern_illum.getPattern(), Utils.formatAsPercent(cursor.getDouble(i + i_illum), 1));
+                                }
                                 //desc = context.getString(R.string.event_at_format, moonStrings[i], context.getString(R.string.location_format_short, config_location_name, config_location_latitude, config_location_longitude));
                                 //desc = context.getString(R.string.event_at_format, moonStrings[i], location[0]);
                                 eventValues.add(adapter.createEventContentValues(calendarID, template.getTitle(data), template.getDesc(data), template.getLocation(data), eventTime));
                                 //Log.d("DEBUG", "create event: " + moonStrings[i] + " at " + eventTime.toString());
                             }
                         }
-                        moonCursor.moveToNext();
+                        cursor.moveToNext();
                         c++;
 
-                        if (c % 128 == 0 || moonCursor.isLast()) {
+                        if (c % 128 == 0 || cursor.isLast()) {
                             adapter.createCalendarEvents( eventValues.toArray(new ContentValues[0]) );
                             eventValues.clear();
                         }
-                        if (c % 8 == 0 || moonCursor.isLast()) {
+                        if (c % 8 == 0 || cursor.isLast()) {
                             progress.setProgress(c, totalProgress, progressTitle);
                             task.publishProgress(progress0, progress);
                         }
                     }
-                    moonCursor.close();
+                    cursor.close();
                     createCalendarReminders(context, task, progress0);
                     return !task.isCancelled();
 

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/SolsticeCalendar.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/SolsticeCalendar.java
@@ -77,6 +77,16 @@ public class SolsticeCalendar extends SuntimesCalendarBase implements SuntimesCa
     }
 
     @Override
+    public TemplatePatterns[] supportedPatterns()
+    {
+        return new TemplatePatterns[] {
+                TemplatePatterns.pattern_event, null, //TemplatePatterns.pattern_eZ, TemplatePatterns.pattern_eA, TemplatePatterns.pattern_eD, TemplatePatterns.pattern_eR, null,
+                TemplatePatterns.pattern_loc, TemplatePatterns.pattern_lat, TemplatePatterns.pattern_lon, TemplatePatterns.pattern_lel, null,
+                TemplatePatterns.pattern_cal, TemplatePatterns.pattern_summary, TemplatePatterns.pattern_color, TemplatePatterns.pattern_percent
+        };
+    }
+
+    @Override
     public CalendarEventStrings defaultStrings() {
         return new CalendarEventStrings(displayStrings);
     }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/SuntimesCalendarBase.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/SuntimesCalendarBase.java
@@ -30,6 +30,7 @@ import com.forrestguice.suntimeswidget.calendar.task.SuntimesCalendar;
 import com.forrestguice.suntimeswidget.calendar.CalendarEventTemplate;
 import com.forrestguice.suntimeswidget.calendar.task.SuntimesCalendarTask;
 import com.forrestguice.suntimeswidget.calendar.task.SuntimesCalendarTaskProgress;
+import com.forrestguice.suntimeswidget.calendar.ui.Utils;
 
 import java.lang.ref.WeakReference;
 
@@ -44,6 +45,7 @@ public abstract class SuntimesCalendarBase implements SuntimesCalendar
     @Override
     public void init(@NonNull Context context, @NonNull SuntimesCalendarSettings settings) {
         contextRef = new WeakReference<>(context);
+        Utils.initDisplayStrings(context);
     }
 
     @Override

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/SuntimesCalendarBase.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/SuntimesCalendarBase.java
@@ -25,6 +25,7 @@ import com.forrestguice.suntimescalendars.R;
 import com.forrestguice.suntimeswidget.calendar.CalendarEventFlags;
 import com.forrestguice.suntimeswidget.calendar.CalendarEventStrings;
 import com.forrestguice.suntimeswidget.calendar.SuntimesCalendarSettings;
+import com.forrestguice.suntimeswidget.calendar.TemplatePatterns;
 import com.forrestguice.suntimeswidget.calendar.task.SuntimesCalendar;
 import com.forrestguice.suntimeswidget.calendar.CalendarEventTemplate;
 import com.forrestguice.suntimeswidget.calendar.task.SuntimesCalendarTask;
@@ -55,6 +56,17 @@ public abstract class SuntimesCalendarBase implements SuntimesCalendar
 
     @Override
     public abstract CalendarEventTemplate defaultTemplate();
+
+    @Override
+    public TemplatePatterns[] supportedPatterns()
+    {
+        return new TemplatePatterns[] {
+                TemplatePatterns.pattern_event, TemplatePatterns.pattern_eZ, TemplatePatterns.pattern_eA, TemplatePatterns.pattern_eD, TemplatePatterns.pattern_eR, null,
+                TemplatePatterns.pattern_illum, TemplatePatterns.pattern_dist, null,
+                TemplatePatterns.pattern_loc, TemplatePatterns.pattern_lat, TemplatePatterns.pattern_lon, TemplatePatterns.pattern_lel, null,
+                TemplatePatterns.pattern_cal, TemplatePatterns.pattern_summary, TemplatePatterns.pattern_color, TemplatePatterns.pattern_percent
+        };
+    }
 
     @Override
     public abstract CalendarEventStrings defaultStrings();

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/TwilightCalendarBase.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/TwilightCalendarBase.java
@@ -32,9 +32,16 @@ import com.forrestguice.suntimeswidget.calendar.task.SuntimesCalendar;
 import com.forrestguice.suntimeswidget.calendar.task.SuntimesCalendarTask;
 import com.forrestguice.suntimeswidget.calendar.CalendarEventTemplate;
 import com.forrestguice.suntimeswidget.calendar.TemplatePatterns;
+import com.forrestguice.suntimeswidget.calendar.ui.Utils;
 
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Map;
+
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract._POSITION_ALT;
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract._POSITION_AZ;
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract._POSITION_DEC;
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract._POSITION_RA;
 
 @SuppressWarnings("Convert2Diamond")
 public abstract class TwilightCalendarBase extends SuntimesCalendarBase implements SuntimesCalendar
@@ -129,6 +136,10 @@ public abstract class TwilightCalendarBase extends SuntimesCalendarBase implemen
         Calendar eventStart = Calendar.getInstance();
         Calendar eventEnd = Calendar.getInstance();
 
+        //if (containsPattern.containsKey(TemplatePatterns.pattern_em)) {
+        //    data.put(TemplatePatterns.pattern_em.getPattern(), eventTime.getTimeInMillis());
+        //}
+
         if (!cursor.isNull(i) && !cursor.isNull(j))                // avg case [i, j]
         {
             eventStart.setTimeInMillis(cursor.getLong(i));
@@ -162,6 +173,63 @@ public abstract class TwilightCalendarBase extends SuntimesCalendarBase implemen
                     cursor.moveToPrevious();
                 }
             }
+        }
+    }
+
+    protected void populatePatternData(Map<TemplatePatterns, Boolean> containsPattern, Map<TemplatePatterns, Integer> i_pattern, Cursor cursor, int offset, ContentValues data)
+    {
+        if (containsPattern.containsKey(TemplatePatterns.pattern_eZ)) {
+            data.put(TemplatePatterns.pattern_eZ.getPattern(), Utils.formatAsDirection(cursor.getDouble(offset + i_pattern.get(TemplatePatterns.pattern_eZ)), 2));
+        }
+        if (containsPattern.containsKey(TemplatePatterns.pattern_eA)) {
+            data.put(TemplatePatterns.pattern_eA.getPattern(), Utils.formatAsElevation(cursor.getDouble(offset + i_pattern.get(TemplatePatterns.pattern_eA)), 2));
+        }
+        if (containsPattern.containsKey(TemplatePatterns.pattern_eR)) {
+            data.put(TemplatePatterns.pattern_eR.getPattern(), Utils.formatAsRightAscension(cursor.getDouble(offset + i_pattern.get(TemplatePatterns.pattern_eR)), 1));
+        }
+        if (containsPattern.containsKey(TemplatePatterns.pattern_eD)) {
+            data.put(TemplatePatterns.pattern_eD.getPattern(), Utils.formatAsDeclination(cursor.getDouble(offset + i_pattern.get(TemplatePatterns.pattern_eD)), 1));
+        }
+    }
+
+    protected void buildContainsPattern(CalendarEventTemplate template, Map<TemplatePatterns, Boolean> containsPattern)
+    {
+        containsPattern.put(TemplatePatterns.pattern_em, template.containsPattern(TemplatePatterns.pattern_em));
+        containsPattern.put(TemplatePatterns.pattern_eZ, template.containsPattern(TemplatePatterns.pattern_eZ));
+        containsPattern.put(TemplatePatterns.pattern_eA, template.containsPattern(TemplatePatterns.pattern_eA));
+        containsPattern.put(TemplatePatterns.pattern_eR, template.containsPattern(TemplatePatterns.pattern_eR));
+        containsPattern.put(TemplatePatterns.pattern_eD, template.containsPattern(TemplatePatterns.pattern_eD));
+    }
+
+    protected void buildExtProjectionFromPatterns(Map<TemplatePatterns, Boolean> containsPattern, Map<TemplatePatterns, Integer> i_pattern, int i, ArrayList<String> projection, String... columns)
+    {
+        if (containsPattern.containsKey(TemplatePatterns.pattern_eZ)) {
+            i_pattern.put(TemplatePatterns.pattern_eZ, i);
+            for (int k=0; k<columns.length; k++) {
+                projection.add(columns[k] + _POSITION_AZ);
+            }
+            i += columns.length;
+        }
+        if (containsPattern.containsKey(TemplatePatterns.pattern_eA)) {
+            i_pattern.put(TemplatePatterns.pattern_eA, i);
+            for (int k=0; k<columns.length; k++) {
+                projection.add(columns[k] + _POSITION_ALT);
+            }
+            i += columns.length;
+        }
+        if (containsPattern.containsKey(TemplatePatterns.pattern_eR)) {
+            i_pattern.put(TemplatePatterns.pattern_eR, i);
+            for (int k=0; k<columns.length; k++) {
+                projection.add(columns[k] + _POSITION_RA);
+            }
+            i += columns.length;
+        }
+        if (containsPattern.containsKey(TemplatePatterns.pattern_eD)) {
+            i_pattern.put(TemplatePatterns.pattern_eD, i);
+            for (int k=0; k<columns.length; k++) {
+                projection.add(columns[k] + _POSITION_DEC);
+            }
+            i += columns.length;
         }
     }
 

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/TwilightCalendarBase.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/TwilightCalendarBase.java
@@ -85,6 +85,16 @@ public abstract class TwilightCalendarBase extends SuntimesCalendarBase implemen
     }
 
     @Override
+    public TemplatePatterns[] supportedPatterns()
+    {
+        return new TemplatePatterns[] {
+                TemplatePatterns.pattern_event, null, //TemplatePatterns.pattern_eZ, TemplatePatterns.pattern_eA, TemplatePatterns.pattern_eD, TemplatePatterns.pattern_eR, null,   // TODO: position patterns
+                TemplatePatterns.pattern_loc, TemplatePatterns.pattern_lat, TemplatePatterns.pattern_lon, TemplatePatterns.pattern_lel, null,
+                TemplatePatterns.pattern_cal, TemplatePatterns.pattern_summary, TemplatePatterns.pattern_color, TemplatePatterns.pattern_percent
+        };
+    }
+
+    @Override
     public CalendarEventFlags defaultFlags() {
         return new CalendarEventFlags();
     }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/TwilightCalendarNautical.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calendar/task/calendars/TwilightCalendarNautical.java
@@ -40,6 +40,13 @@ import com.forrestguice.suntimeswidget.calendar.TemplatePatterns;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract.COLUMN_SUN_CIVIL_RISE;
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract.COLUMN_SUN_CIVIL_SET;
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract.COLUMN_SUN_NAUTICAL_RISE;
+import static com.forrestguice.suntimeswidget.calculator.core.CalculatorProviderContract.COLUMN_SUN_NAUTICAL_SET;
 
 @SuppressWarnings("Convert2Diamond")
 public class TwilightCalendarNautical extends TwilightCalendarBase implements SuntimesCalendar
@@ -55,7 +62,7 @@ public class TwilightCalendarNautical extends TwilightCalendarBase implements Su
 
     @Override
     public CalendarEventTemplate defaultTemplate() {
-        return new CalendarEventTemplate("%cal", "%M @ %loc", "%loc");
+        return new CalendarEventTemplate("%cal", "%M @ %loc\n%eZ", "%loc");
     }
 
     @Override
@@ -110,9 +117,24 @@ public class TwilightCalendarNautical extends TwilightCalendarBase implements Su
             ContentResolver resolver = (context == null ? null : context.getContentResolver());
             if (resolver != null)
             {
+                ArrayList<String> projection0 = new ArrayList<>(Arrays.asList(
+                        COLUMN_SUN_NAUTICAL_RISE, COLUMN_SUN_CIVIL_RISE,    // 0, 1
+                        COLUMN_SUN_CIVIL_SET, COLUMN_SUN_NAUTICAL_SET ));   // 2, 3
+
+                CalendarEventTemplate template = SuntimesCalendarSettings.loadPrefCalendarTemplate(context, calendarName, defaultTemplate());
+                boolean[] flags = SuntimesCalendarSettings.loadPrefCalendarFlags(context, calendarName, defaultFlags()).getValues();
+                String[] strings = SuntimesCalendarSettings.loadPrefCalendarStrings(context, calendarName, defaultStrings()).getValues();
+                // 0:s_NAUTICAL_TWILIGHT, 1:s_NAUTICAL_TWILIGHT_MORNING, 2:s_NAUTICAL_TWILIGHT_EVENING, 3:s_NAUTICAL_DAWN, 4:s_NAUTICAL_DUSK, 5:s_CIVIL_NIGHT
+
+                Map<TemplatePatterns, Boolean> containsPattern = new HashMap<>();
+                Map<TemplatePatterns, Integer> i_pattern = new HashMap<>();
+                buildContainsPattern(template, containsPattern);
+                buildExtProjectionFromPatterns(containsPattern, i_pattern, projection0.size(), projection0,
+                        COLUMN_SUN_NAUTICAL_RISE, COLUMN_SUN_NAUTICAL_SET);    // 4, 5  .. rising position, setting position, etc
+
                 Uri uri = Uri.parse("content://" + CalculatorProviderContract.AUTHORITY + "/" + CalculatorProviderContract.QUERY_SUN + "/" + window[0] + "-" + window[1]);
-                String[] projection = new String[] { CalculatorProviderContract.COLUMN_SUN_NAUTICAL_RISE, CalculatorProviderContract.COLUMN_SUN_CIVIL_RISE,
-                        CalculatorProviderContract.COLUMN_SUN_CIVIL_SET, CalculatorProviderContract.COLUMN_SUN_NAUTICAL_SET };
+                String[] projection = projection0.toArray(new String[0]);
+
                 Cursor cursor = resolver.query(uri, projection, null, null, null);
                 if (cursor != null)
                 {
@@ -125,11 +147,6 @@ public class TwilightCalendarNautical extends TwilightCalendarBase implements Su
                     SuntimesCalendarTaskProgress progress = new SuntimesCalendarTaskProgress(c, numRows, progressTitle);
                     task.publishProgress(progress0, progress);
 
-                    boolean[] flags = SuntimesCalendarSettings.loadPrefCalendarFlags(context, calendarName, defaultFlags()).getValues();
-                    String[] strings = SuntimesCalendarSettings.loadPrefCalendarStrings(context, calendarName, defaultStrings()).getValues();
-                    // 0:s_NAUTICAL_TWILIGHT, 1:s_NAUTICAL_TWILIGHT_MORNING, 2:s_NAUTICAL_TWILIGHT_EVENING, 3:s_NAUTICAL_DAWN, 4:s_NAUTICAL_DUSK, 5:s_CIVIL_NIGHT
-
-                    CalendarEventTemplate template = SuntimesCalendarSettings.loadPrefCalendarTemplate(context, calendarName, defaultTemplate());
                     ContentValues data = TemplatePatterns.createContentValues(null, this);
                     data = TemplatePatterns.createContentValues(data, task.getLocation());
 
@@ -138,9 +155,11 @@ public class TwilightCalendarNautical extends TwilightCalendarBase implements Su
                     while (!cursor.isAfterLast() && !task.isCancelled())
                     {
                         if (flags[0]) {
+                            populatePatternData(containsPattern, i_pattern, cursor, 0, data);
                             createSunCalendarEvent(context, adapter, task, eventValues, calendarID, cursor, 0, template, data, strings[1], strings[5], strings[0]);   // nautical twilight (morning), civil night, nautical twilight
                         }
                         if (flags[1]) {
+                            populatePatternData(containsPattern, i_pattern, cursor, 1, data);
                             createSunCalendarEvent(context, adapter, task, eventValues, calendarID, cursor, 2, template, data, strings[2], strings[0], strings[0]);   // nautical twilight (evening), nautical twilight, nautical twilight
                         }
                         cursor.moveToNext();

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calendar/ui/Utils.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calendar/ui/Utils.java
@@ -27,7 +27,6 @@ import android.util.Log;
 
 import com.forrestguice.suntimescalendars.R;
 
-import java.text.DecimalFormat;
 import java.text.NumberFormat;
 
 public class Utils
@@ -50,6 +49,7 @@ public class Utils
     protected static String strDeclinationFormat = "%1$s %2$s";
     protected static String strRaFormat = "%1$s %2$s";
     protected static String strDistanceFormatKm = "%1$s km";
+    protected static String strDistanceFormatMi = "%1$s mi";
     protected static String strPercentFormat = "%1$s %%";
 
     private static NumberFormat formatter = NumberFormat.getInstance();
@@ -97,14 +97,33 @@ public class Utils
         return String.format(strElevationFormat, formatAsDegrees(degrees, places), strAltSymbol);
     }
 
-    public static String formatAsDistanceKm(Double value, int places)
+    public static String formatAsDistance(LengthUnit lengthUnits, Double distanceKm, int places) {
+        return formatAsDistance(lengthUnits.name(), distanceKm, places);
+    }
+    public static String formatAsDistance(String lengthUnits, Double distanceKm, int places)
+    {
+        if (distanceKm == null) {
+            return "";
+        }
+        boolean asImperial = Utils.LengthUnit.IMPERIAL.name().equals(lengthUnits);
+        double value = (asImperial ? Utils.LengthUnit.kilometersToMiles(distanceKm) : distanceKm);
+        return asImperial ? Utils.formatAsDistanceMi(value, places)
+                : Utils.formatAsDistanceKm(value, places);
+    }
+    public static String formatAsDistanceKm(Double value, int places) {
+        return formatAsDistance(value, places, strDistanceFormatKm);
+    }
+    public static String formatAsDistanceMi(Double value, int places) {
+        return formatAsDistance(value, places, strDistanceFormatMi);
+    }
+    public static String formatAsDistance(Double value, int places, String format)
     {
         if (value == null) {
             return "";
         }
-        formatter.setMinimumFractionDigits(places);
+        formatter.setMinimumFractionDigits(0);
         formatter.setMaximumFractionDigits(places);
-        return String.format(strDistanceFormatKm, formatter.format(value));
+        return String.format(format, formatter.format(value));
     }
 
     public static String formatAsPercent(Double value, int places)
@@ -239,6 +258,7 @@ public class Utils
     public static void initDisplayStrings( Context context )
     {
         CardinalDirection.initDisplayStrings(context);
+        LengthUnit.initDisplayStrings(context);
 
         strDegSymbol = context.getString(R.string.degrees_symbol);                // "%";
         strAltSymbol = context.getString(R.string.altitude_symbol);               // "∠";
@@ -249,8 +269,50 @@ public class Utils
         strElevationFormat = context.getString(R.string.elevation_format);        // "%1$s%2$s";
         strDeclinationFormat = context.getString(R.string.declination_format);    // "%1$s %2$s";
         strRaFormat = context.getString(R.string.rightascension_format);          //"%1$s %2$s";
-        strDistanceFormatKm = context.getString(R.string.distance_format);
+        strDistanceFormatKm = context.getString(R.string.distance_format_km);
+        strDistanceFormatMi = context.getString(R.string.distance_format_mi);
         strPercentFormat = context.getString(R.string.percent_format);            // "%1$s %%";
     }
+
+    /**
+     * LengthUnit
+     */
+    public static enum LengthUnit
+    {
+        METRIC("Metric"),
+        IMPERIAL("Imperial");
+
+        private LengthUnit(String displayString) {
+            this.displayString = displayString;
+        }
+
+        private String displayString;
+        public String getDisplayString() {
+            return displayString;
+        }
+        public void setDisplayString(String value) {
+            displayString = value;
+        }
+        public static void initDisplayStrings(Context context)
+        {
+            METRIC.setDisplayString(context.getString(R.string.lengthUnits_metric));
+            IMPERIAL.setDisplayString(context.getString(R.string.lengthUnits_imperial));
+        }
+        public String toString() {
+            return displayString;
+        }
+
+        public static double metersToFeet(double meters) {
+            return 3.28084d * meters;
+        }
+        public static double feetToMeters(double feet) {
+            return (feet * (1d / 3.28084d) );
+        }
+
+        public static double kilometersToMiles(double kilometers) {
+            return 0.62137 * kilometers;
+        }
+    }
+
 
 }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calendar/ui/Utils.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calendar/ui/Utils.java
@@ -40,7 +40,8 @@ public class Utils
         } else return Html.fromHtml(source);
     }
 
-    protected static String strAltSymbol = "∠";    // TODO: i18n
+    protected static String strDegSymbol = "°";
+    protected static String strAltSymbol = "∠";
     protected static String strRaSymbol = "α";
     protected static String strDecSymbol = "δ";
     protected static String strDegreesFormat = "%1$s\u00B0";
@@ -238,7 +239,18 @@ public class Utils
     public static void initDisplayStrings( Context context )
     {
         CardinalDirection.initDisplayStrings(context);
-        // TODO: others
+
+        strDegSymbol = context.getString(R.string.degrees_symbol);                // "%";
+        strAltSymbol = context.getString(R.string.altitude_symbol);               // "∠";
+        strRaSymbol = context.getString(R.string.rightascension_symbol);          // "α";
+        strDecSymbol = context.getString(R.string.declination_symbol);            //"δ";
+        strDegreesFormat = context.getString(R.string.degrees_format);            // "%1$s\u00B0";
+        strDirectionFormat = context.getString(R.string.direction_format);        // "%1$s\u00A0%2$s";
+        strElevationFormat = context.getString(R.string.elevation_format);        // "%1$s%2$s";
+        strDeclinationFormat = context.getString(R.string.declination_format);    // "%1$s %2$s";
+        strRaFormat = context.getString(R.string.rightascension_format);          //"%1$s %2$s";
+        strDistanceFormatKm = context.getString(R.string.distance_format);
+        strPercentFormat = context.getString(R.string.percent_format);            // "%1$s %%";
     }
 
 }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calendar/ui/Utils.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calendar/ui/Utils.java
@@ -27,6 +27,7 @@ import android.util.Log;
 
 import com.forrestguice.suntimescalendars.R;
 
+import java.text.DecimalFormat;
 import java.text.NumberFormat;
 
 public class Utils
@@ -47,6 +48,8 @@ public class Utils
     protected static String strElevationFormat = "%1$s%2$s";
     protected static String strDeclinationFormat = "%1$s %2$s";
     protected static String strRaFormat = "%1$s %2$s";
+    protected static String strDistanceFormatKm = "%1$s km";
+    protected static String strPercentFormat = "%1$s %%";
 
     private static NumberFormat formatter = NumberFormat.getInstance();
 
@@ -91,6 +94,26 @@ public class Utils
 
     public static String formatAsElevation(Double degrees, int places) {
         return String.format(strElevationFormat, formatAsDegrees(degrees, places), strAltSymbol);
+    }
+
+    public static String formatAsDistanceKm(Double value, int places)
+    {
+        if (value == null) {
+            return "";
+        }
+        formatter.setMinimumFractionDigits(places);
+        formatter.setMaximumFractionDigits(places);
+        return String.format(strDistanceFormatKm, formatter.format(value));
+    }
+
+    public static String formatAsPercent(Double value, int places)
+    {
+        if (value == null) {
+            return "";
+        }
+        formatter.setMinimumFractionDigits(places);
+        formatter.setMaximumFractionDigits(places);
+        return String.format(strPercentFormat, formatter.format(value * 100));
     }
 
     /**

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calendar/ui/Utils.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calendar/ui/Utils.java
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020 Forrest Guice
+    Copyright (C) 2020-2024 Forrest Guice
     This file is part of SuntimesCalendars.
 
     SuntimesCalendars is free software: you can redistribute it and/or modify
@@ -17,9 +17,17 @@
 */
 package com.forrestguice.suntimeswidget.calendar.ui;
 
+import android.content.Context;
+import android.content.res.Resources;
 import android.os.Build;
+import android.support.annotation.Nullable;
 import android.text.Html;
 import android.text.Spanned;
+import android.util.Log;
+
+import com.forrestguice.suntimescalendars.R;
+
+import java.text.NumberFormat;
 
 public class Utils
 {
@@ -30,4 +38,184 @@ public class Utils
             return Html.fromHtml(source, Html.FROM_HTML_MODE_LEGACY);
         } else return Html.fromHtml(source);
     }
+
+    protected static String strAltSymbol = "∠";    // TODO: i18n
+    protected static String strRaSymbol = "α";
+    protected static String strDecSymbol = "δ";
+    protected static String strDegreesFormat = "%1$s\u00B0";
+    protected static String strDirectionFormat = "%1$s\u00A0%2$s";
+    protected static String strElevationFormat = "%1$s%2$s";
+    protected static String strDeclinationFormat = "%1$s %2$s";
+    protected static String strRaFormat = "%1$s %2$s";
+
+    private static NumberFormat formatter = NumberFormat.getInstance();
+
+    public static String formatAsDegrees(@Nullable Double value, int places)
+    {
+        if (value == null) {
+            return "";
+        }
+        formatter.setMinimumFractionDigits(places);
+        formatter.setMaximumFractionDigits(places);
+        return String.format(strDegreesFormat, formatter.format(value));
+    }
+
+    public static String formatAsRightAscension(Double degrees, int places)
+    {
+        if (degrees == null) {
+            return "";
+        }
+        return String.format(strRaFormat, formatAsDegrees(degrees, places), strRaSymbol);
+    }
+
+    public static String formatAsDeclination(Double degrees, int places)
+    {
+        if (degrees == null) {
+            return "";
+        }
+        return String.format(strDeclinationFormat, formatAsDegrees(degrees, places), strDecSymbol);
+    }
+
+    public static String formatAsDirection(Double degrees, int places)
+    {
+        if (degrees == null) {
+            return "";
+        }
+        String degreeString = formatAsDegrees(degrees, places);
+        Utils.CardinalDirection direction = Utils.CardinalDirection.getDirection(degrees);
+        return formatAsDirection(degreeString, direction.getShortDisplayString());
+    }
+    public static String formatAsDirection(String degreeString, String directionString) {
+        return String.format(strDirectionFormat, degreeString, directionString);
+    }
+
+    public static String formatAsElevation(Double degrees, int places) {
+        return String.format(strElevationFormat, formatAsDegrees(degrees, places), strAltSymbol);
+    }
+
+    /**
+     * CardinalDirection
+     */
+    public static enum CardinalDirection
+    {
+        NORTH(1,      "N",   "North"              , 0.0),
+        NORTH_NE(2,   "NNE", "North North East"   , 22.5),
+        NORTH_E(3,    "NE",  "North East"         , 45.0),
+
+        EAST_NE(4,    "ENE", "East North East"    , 67.5),
+        EAST(5,       "E",   "East"               , 90.0),
+        EAST_SE(6,    "ESE", "East South East"    , 112.5),
+
+        SOUTH_E(7,    "SE",  "South East"         , 135.0),
+        SOUTH_SE(8,   "SSE", "South South East"   , 157.5),
+        SOUTH(9,      "S",   "South"              , 180.0),
+        SOUTH_SW(10,  "SSW", "South South West"   , 202.5),
+        SOUTH_W(11,   "SW",  "South West"         , 225.0),
+
+        WEST_SW(12,   "WSW", "West South West"    , 247.5),
+        WEST(13,      "W",   "West"               , 270.0),
+        WEST_NW(14,   "WNW", "West North West"    , 292.5),
+
+        NORTH_W(15,   "NW",  "North West"         , 315.0),
+        NORTH_NW(16,  "NNW", "North North West"   , 337.5),
+        NORTH2(1,     "N",   "North"              , 360.0);
+
+        private int pointNum;
+        private String shortDisplayString;
+        private String longDisplayString;
+        private double degrees;
+
+        private CardinalDirection(int pointNum, String shortDisplayString, String longDisplayString, double degrees)
+        {
+            this.pointNum = pointNum;
+            this.shortDisplayString = shortDisplayString;
+            this.longDisplayString = longDisplayString;
+            this.degrees = degrees;
+        }
+
+        public static CardinalDirection getDirection(double degrees)
+        {
+            if (degrees > 360)
+                degrees = degrees % 360;
+
+            while (degrees < 0)
+                degrees += 360;
+
+            CardinalDirection result = NORTH;
+            double least = Double.MAX_VALUE;
+            for (CardinalDirection direction : values())
+            {
+                double directionDegrees = direction.getDegress();
+                double diff = Math.abs(directionDegrees - degrees);
+                if (diff < least)
+                {
+                    least = diff;
+                    result = direction;
+                }
+            }
+            return result;
+        }
+
+        public String toString()
+        {
+            return shortDisplayString;
+        }
+
+        public double getDegress()
+        {
+            return degrees;
+        }
+
+        public int getPoint()
+        {
+            return pointNum;
+        }
+
+        public String getShortDisplayString()
+        {
+            return shortDisplayString;
+        }
+
+        public String getLongDisplayString()
+        {
+            return longDisplayString;
+        }
+
+        public void setDisplayStrings(String shortDisplayString, String longDisplayString)
+        {
+            this.shortDisplayString = shortDisplayString;
+            this.longDisplayString = longDisplayString;
+        }
+
+        public static void initDisplayStrings( Context context )
+        {
+            Resources res = context.getResources();
+            String[] modes_short = res.getStringArray(R.array.directions_short);
+            String[] modes_long = res.getStringArray(R.array.directions_long);
+            if (modes_long.length != modes_short.length)
+            {
+                Log.e("initDisplayStrings", "The size of directions_short and solarevents_long DOES NOT MATCH!");
+                return;
+            }
+
+            CardinalDirection[] values = values();
+            if (modes_long.length != values.length)
+            {
+                Log.e("initDisplayStrings", "The size of directions_long and SolarEvents DOES NOT MATCH!");
+                return;
+            }
+
+            for (int i = 0; i < values.length; i++)
+            {
+                values[i].setDisplayStrings(modes_short[i], modes_long[i]);
+            }
+        }
+    }
+
+    public static void initDisplayStrings( Context context )
+    {
+        CardinalDirection.initDisplayStrings(context);
+        // TODO: others
+    }
+
 }

--- a/app/src/main/java/com/forrestguice/suntimeswidget/calendar/ui/template/TemplateDialog.java
+++ b/app/src/main/java/com/forrestguice/suntimeswidget/calendar/ui/template/TemplateDialog.java
@@ -100,6 +100,14 @@ public class TemplateDialog extends BottomSheetDialogFragment
     public static final String KEY_DATA = "data";
 
     /**
+     * setSupportedPatterns
+     */
+    public void setSupportedPatterns(TemplatePatterns... patterns) {
+        supportedPatterns = patterns;
+    }
+    protected TemplatePatterns[] supportedPatterns = TemplatePatterns.values();
+
+    /**
      * getResult
      */
     public CalendarEventTemplate getResult() {
@@ -329,7 +337,7 @@ public class TemplateDialog extends BottomSheetDialogFragment
     {
         HelpDialog helpDialog = new HelpDialog();
         helpDialog.setShowDefaultsButton(true);
-        helpDialog.setContent(getString(R.string.help_template, TemplatePatterns.getAllHelpText(getActivity())) + "<br/>");
+        helpDialog.setContent(getString(R.string.help_template, TemplatePatterns.getPatternHelpText(getActivity(), supportedPatterns)) + "<br/>");
         helpDialog.setDialogListener(helpDialogListener);
         helpDialog.show(getChildFragmentManager(), DIALOGTAG_HELP);
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -344,7 +344,8 @@
     <string name="help_pattern_lat">location latitude</string>   <!-- TODO -->
     <string name="help_pattern_lon">location longitude</string>   <!-- TODO -->
     <string name="help_pattern_lel">location elevation</string>   <!-- TODO -->
-    <string name="help_pattern_event">event title (e.g. "Full Moon").</string>   <!-- TODO -->
+    <string name="help_pattern_event">event title (e.g. "Full Moon")</string>   <!-- TODO -->
+    <string name="help_pattern_event_millis">event milliseconds</string>   <!-- TODO -->
     <string name="help_pattern_dist">moon distance</string>   <!-- TODO -->
     <string name="help_pattern_illum">moon illumination</string>   <!-- TODO -->
     <string name="help_pattern_phase">moon phase</string>   <!-- TODO -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -291,6 +291,11 @@
     <string name="help_pattern_event">event title (e.g. "Full Moon").</string>   <!-- TODO -->
     <string name="help_pattern_dist">moon distance</string>   <!-- TODO -->
     <string name="help_pattern_illum">moon illumination</string>   <!-- TODO -->
+    <string name="help_pattern_phase">moon phase</string>   <!-- TODO -->
+    <string name="help_pattern_altitude">event altitude</string>   <!-- TODO -->
+    <string name="help_pattern_azimuth">event azimuth</string>   <!-- TODO -->
+    <string name="help_pattern_declination">event declination</string>   <!-- TODO -->
+    <string name="help_pattern_rightascension">event right ascension</string>   <!-- TODO -->
     <string name="help_pattern_percent">\% character</string>   <!-- TODO -->
 
     <string name="help_flags"><![CDATA[

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -281,6 +281,46 @@
 
     <string name="action_restore_defaults">Restore Defaults</string>  <!-- TODO -->
 
+    <!-- cardinal directions -->
+    <string-array name="directions_short">  <!-- one-to-one with directions_long -->
+        <item>N</item>
+        <item>NNE</item>
+        <item>NE</item>
+        <item>ENE</item>
+        <item>E</item>
+        <item>ESE</item>
+        <item>SE</item>
+        <item>SSE</item>
+        <item>S</item>
+        <item>SSW</item>
+        <item>SW</item>
+        <item>WSW</item>
+        <item>W</item>
+        <item>WNW</item>
+        <item>NW</item>
+        <item>NNW</item>
+        <item>N</item>
+    </string-array>
+    <string-array name="directions_long">   <!-- one-to-one with directions_short -->
+        <item>North</item>
+        <item>North North East</item>
+        <item>North East</item>
+        <item>East North East</item>
+        <item>East</item>
+        <item>East South East</item>
+        <item>South East</item>
+        <item>South South East</item>
+        <item>South</item>
+        <item>South South West</item>
+        <item>South West</item>
+        <item>West South West</item>
+        <item>West</item>
+        <item>West North West</item>
+        <item>North West</item>
+        <item>North North West</item>
+        <item>North</item>
+    </string-array>
+
     <string name="help_pattern_cal">calendar (e.g. "Civil Twilight")</string>   <!-- TODO -->
     <string name="help_pattern_summary">summary (e.g. "Sunrise / Sunset")</string>   <!-- TODO -->
     <string name="help_pattern_color">calendar color (e.g. "#FFFFFF")</string>   <!-- TODO -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -247,7 +247,8 @@
     <string name="event_distance_format">%s\n%s km</string>  <!-- e.g. full moon (400.71 km) -->
     <string name="summarylist_format">%s\n%s</string>
 
-    <string name="distance_format">%s km</string>  <!-- e.g. full moon (400.71 km) -->   <!-- TODO -->
+    <string name="distance_format_km">%s km</string>  <!-- e.g. full moon (400.71 km) -->   <!-- TODO -->
+    <string name="distance_format_mi">%s mi</string>   <!-- TODO -->
     <!--<string name="distance_format"><xliff:g id="value" example="6">%1$s</xliff:g>&#160;<xliff:g id="units_short" example="ft">%2$s</xliff:g></string>-->  <!-- e.g. 6 ft (shadow length), 250,000 mi (distance to moon) -->
 
     <!-- position formats -->
@@ -335,6 +336,18 @@
         <item>North West</item>
         <item>North North West</item>
         <item>North</item>
+    </string-array>
+
+    <!-- distances (meters, feet, etc) -->
+    <string name="lengthUnits_metric">Metric</string>
+    <string name="lengthUnits_imperial">Imperial</string>
+    <string-array name="lengthUnits_values" translatable="false">
+        <item>METRIC</item>
+        <item>IMPERIAL</item>
+    </string-array>
+    <string-array name="lengthUnits_display"> <!-- one-to-one with lengthUnits_values -->
+        <item>@string/lengthUnits_metric</item>
+        <item>@string/lengthUnits_imperial</item>
     </string-array>
 
     <string name="help_pattern_cal">calendar (e.g. "Civil Twilight")</string>   <!-- TODO -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -246,7 +246,23 @@
     <string name="event_at_format">%s @ %s</string>  <!-- e.g. moonrise at location_format -->
     <string name="event_distance_format">%s\n%s km</string>  <!-- e.g. full moon (400.71 km) -->
     <string name="summarylist_format">%s\n%s</string>
+
     <string name="distance_format">%s km</string>  <!-- e.g. full moon (400.71 km) -->   <!-- TODO -->
+    <!--<string name="distance_format"><xliff:g id="value" example="6">%1$s</xliff:g>&#160;<xliff:g id="units_short" example="ft">%2$s</xliff:g></string>-->  <!-- e.g. 6 ft (shadow length), 250,000 mi (distance to moon) -->
+
+    <!-- position formats -->
+    <string name="degrees_format"><xliff:g id="value" example="45">%1$s</xliff:g>°</string>  <!-- e.g. 45° -->
+    <string name="elevation_format"><xliff:g id="degrees" example="45">%1$s</xliff:g><xliff:g id="altSymbol" example="∠">%2$s</xliff:g></string>  <!-- e.g. 45°∠ -->
+    <string name="declination_format"><xliff:g id="degrees" example="45">%1$s</xliff:g><xliff:g id="decSymbol" example="δ">%2$s</xliff:g></string>  <!-- e.g. 5° δ -->
+    <string name="rightascension_format"><xliff:g id="degrees" example="45">%1$s</xliff:g><xliff:g id="raSymbol" example="δ">%2$s</xliff:g></string>  <!-- e.g. 5° α -->
+    <string name="direction_format"><xliff:g id="degrees" example="180°">%1$s</xliff:g> <xliff:g id="directions_short" example="S">%2$s</xliff:g></string>  <!-- e.g. 180°S -->
+    <string name="percent_format"><xliff:g id="value" example="45">%1$s</xliff:g>%%</string>  <!-- e.g. 45% -->
+
+    <string name="percent_symbol">%%</string>                <!-- label/suffix -->
+    <string name="degrees_symbol">°</string>                <!-- label/suffix -->
+    <string name="altitude_symbol">∠</string>               <!-- label/suffix -->
+    <string name="declination_symbol">δ</string>            <!-- label/suffix -->
+    <string name="rightascension_symbol">α</string>         <!-- label/suffix -->
 
     <string name="toolbar_title">Calendars</string>
 


### PR DESCRIPTION
* adds patterns to the "Moon" calendar; `%em` (milliseconds), `%eZ` (azimuth), `%eA` (altitude), `%eR` (right ascension), `%eD` (declination), `%illum` (illumination %), `%phase` (minor phase), and `%dist` (distance).
* adds patterns to the "Daylight", "Civil Twilight", "Nautical Twilight", "Astronomical Twilight", "Blue Hour", and "Gold Hour" calendars; `%em` (milliseconds), `%eZ` (azimuth), `%eA` (altitude), `%eR` (right ascension), and `%eD` (declination).
* changes default calendar templates to include the `%eZ` and `%eA` patterns where applicable.
* fixes `%dist` pattern to respect the Suntimes "length units" option; now displays the distance in km or mi.
* improves template pattern help so that only the supported patterns for each individual calendar are shown.
* bumps "CalculatorProviderContract" version 5->7.